### PR TITLE
Added advanced test for <span> tags

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -1,116 +1,100 @@
-[
-
-{
-  "id": "oldURLs",
-  "name": "Old 'en/' URLs",
-  "desc": "en/ -> /en-US/docs/",
-  "regex": "\\shref=\"\\/*en*\/",
-  "count": 0
-},
-
-{
-  "id": "emptyElem",
-  "name": "Empty elements",
-  "desc": "E.g. <p></p>",
-  "regex": "(<(?!\\/)[^>]+>)+([\\s]*?)(<\\/[^>]+>)+",
-  "count": 0
-},
-
-{
-  "id": "languagesMacro",
-  "name": "Languages macro",
-  "desc": "{{languages()}}",
-  "regex": "{{\\s*languages\\s*",
-  "count": 0
-},
-
-
-{
-  "id": "emptyBrackets",
-  "name": "Empty brackets",
-  "desc": "{{foo()}}",
-  "regex": "{{\\s*[a-z]*\\(\\)\\s*}}",
-  "count": 0
-},
-
-{
-  "id": "styleAttribute",
-  "name": "Style attributes",
-  "desc": "style=",
-  "regex": "style=[\"'][a-zA-Z0-9:#!%;'\\.\\s\\(\\)\\-\\,]*['\"]",
-  "count": 0
-},
-
-{
-  "id": "nameAttribute",
-  "name": "Name attributes",
-  "desc": "name=",
-  "regex": "name=[\"'][a-zA-Z0-9:#!%;'_\\.\\s\\(\\)\\-\\,]*['\"]",
-  "count": 0
-},
-
-{
-  "id": "spanCount",
-  "name": "# of &lt;span&gt; elements",
-  "desc": "<span></span>",
-  "regex": "(<span[^>]*>).*?<\\/span>",
-  "count": 0
-},
-
-{
-  "id": "preWithoutClass",
-  "name": "&lt;pre&gt; w/o class",
-  "desc": "<pre></pre> (no syntax highlighter)",
-  "regex": "(<pre(?=\\s|>)(?!(?:[^>=]|=(['\"])(?:(?!\\1).)*\\1)*?class=['\"])[^>]*>[\\S\\s]*?<\\/pre>)",
-  "count": 0
-},
-
-{
-  "id": "SummaryHeading",
-  "name": "Summary heading",
-  "desc": "According to the article style guide there shouldn't be a <hx>Summary</hx> heading.",
-  "regex": "<h[0-6]?(?!\\/)[^>]+>Summary<\\/h[0-6]>",
-  "count": 0
-},
-
-{
-  "id": "jsRefWithParams",
-  "name": "JSRef params",
-  "desc": "Paremeters are obsolete now, e.g. {{JSRef('Global_Objects', 'Math')}}",
-  "regex": "{{s*JSRef\\(s*",
-  "count": 0
-},
-
-{
-  "id": "ExampleColonHeading",
-  "name": "'Example:' heading",
-  "desc": "<h3>Example: Foobar</h3> just use <h3>Foobar</h3>",
-  "regex": "<h[0-6]?(?!\\/)[^>]+>Example:.*?<\\/h[0-6]>",
-  "count": 0
-},
-
-{
-  "id": "alertPrintInCode",
-  "name": "alert, print, eval, d.write",
-  "desc": "Don't use alert, print, eval, document.write in code samples",
-  "regex": "(alert|print|eval|document\\.write)",
-  "count": 0
-},
-
-{
-  "id": "htmlComments",
-  "name": "HTML comments",
-  "desc": "HTML comments are not visible in wysiwyg mode and in reading mode. Not meant to comment the documentation",
-  "regex": "<!--[\\s\\S]*?-->",
-  "count": 0
-},
-
-{
-  "id": "fontElement",
-  "name": "&lt;font&gt; element",
-  "desc": "Using <font> elements is obsolete. Either the tag should be removed completely or replaced by CSS.",
-  "regex": "<font.*?>",
-  "count": 0
-}
-
-]
+var docTests = [
+  {
+    id: "oldURLs",
+    name: "Old 'en/' URLs",
+    desc: "en/ -> /en-US/docs/",
+    regex: "\\shref=\"\\/*en*\/",
+    count: 0
+  },
+  {
+    id: "emptyElem",
+    name: "Empty elements",
+    desc: "E.g. <p></p>",
+    regex: "(<(?!\\/)[^>]+>)+([\\s]*?)(<\\/[^>]+>)+",
+    count: 0
+  },
+  {
+    id: "languagesMacro",
+    name: "Languages macro",
+    desc: "{{languages()}}",
+    regex: "{{\\s*languages\\s*",
+    count: 0
+  },
+  {
+    id: "emptyBrackets",
+    name: "Empty brackets",
+    desc: "{{foo()}}",
+    regex: "{{\\s*[a-z]*\\(\\)\\s*}}",
+    count: 0
+  },
+  {
+    id: "styleAttribute",
+    name: "Style attributes",
+    desc: "style=",
+    regex: "style=[\"'][a-zA-Z0-9:#!%;'\\.\\s\\(\\)\\-\\,]*['\"]",
+    count: 0
+  },
+  {
+    id: "nameAttribute",
+    name: "Name attributes",
+    desc: "name=",
+    regex: "name=[\"'][a-zA-Z0-9:#!%;'_\\.\\s\\(\\)\\-\\,]*['\"]",
+    count: 0
+  },
+  {
+    id: "spanCount",
+    name: "# of &lt;span&gt; elements",
+    desc: "<span></span>",
+    regex: "(<span[^>]*>).*?<\\/span>",
+    count: 0
+  },
+  {
+    id: "preWithoutClass",
+    name: "&lt;pre&gt; w/o class",
+    desc: "<pre></pre> (no syntax highlighter)",
+    regex: "(<pre(?=\\s|>)(?!(?:[^>=]|=(['\"])(?:(?!\\1).)*\\1)*?class=['\"])[^>]*>[\\S\\s]*?<\\/pre>)",
+    count: 0
+  },
+  {
+    id: "SummaryHeading",
+    name: "Summary heading",
+    desc: "According to the article style guide there shouldn't be a <hx>Summary</hx> heading.",
+    regex: "<h[0-6]?(?!\\/)[^>]+>Summary<\\/h[0-6]>",
+    count: 0
+  },
+  {
+    id: "jsRefWithParams",
+    name: "JSRef params",
+    desc: "Paremeters are obsolete now, e.g. {{JSRef('Global_Objects', 'Math')}}",
+    regex: "{{s*JSRef\\(s*",
+    count: 0
+  },
+  {
+    id: "ExampleColonHeading",
+    name: "'Example:' heading",
+    desc: "<h3>Example: Foobar</h3> just use <h3>Foobar</h3>",
+    regex: "<h[0-6]?(?!\\/)[^>]+>Example:.*?<\\/h[0-6]>",
+    count: 0
+  },
+  {
+    id: "alertPrintInCode",
+    name: "alert, print, eval, d.write",
+    desc: "Don't use alert, print, eval, document.write in code samples",
+    regex: "(alert|print|eval|document\\.write)",
+    count: 0
+  },
+  {
+    id: "htmlComments",
+    name: "HTML comments",
+    desc: "HTML comments are not visible in wysiwyg mode and in reading mode. Not meant to comment the documentation",
+    regex: "<!--[\\s\\S]*?-->",
+    count: 0
+  },
+  {
+    id: "fontElement",
+    name: "&lt;font&gt; element",
+    desc: "Using <font> elements is obsolete. Either the tag should be removed completely or replaced by CSS.",
+    regex: "<font.*?>",
+    count: 0
+  }
+];

--- a/data/doctests.js
+++ b/data/doctests.js
@@ -45,7 +45,16 @@ var docTests = [
     id: "spanCount",
     name: "# of &lt;span&gt; elements",
     desc: "<span></span>",
-    regex: "(<span[^>]*>).*?<\\/span>",
+    check: function check(content) {
+      var matches = content.match(/<span.*?>.*?<\/span>/gi);
+      for (var i = 0; i < matches.length; i++) {
+        if (matches[i].match(/<span[^>]*?class="seoSummary"/)) {
+          matches.splice(i, 1);
+        }
+      }
+
+      return matches;
+    },
     count: 0
   },
   {

--- a/data/doctests.js
+++ b/data/doctests.js
@@ -46,7 +46,7 @@ var docTests = [
     name: "# of &lt;span&gt; elements",
     desc: "<span></span>",
     check: function check(content) {
-      var matches = content.match(/<span.*?>.*?<\/span>/gi);
+      var matches = content.match(/<span.*?>.*?<\/span>/gi) || [];
       for (var i = 0; i < matches.length; i++) {
         if (matches[i].match(/<span[^>]*?class="seoSummary"/)) {
           matches.splice(i, 1);

--- a/data/runtests.js
+++ b/data/runtests.js
@@ -8,8 +8,8 @@ var runTest = function(testObj) {
   self.port.emit("test", testObj);
 };
 
-self.port.on("runTests", function(docTests) {
-  for (var i = 0; i <= docTests.length; i++) {
+self.port.on("runTests", function() {
+  for (var i = 0; i < docTests.length; i++) {
     runTest(docTests[i]);
   }
 });

--- a/data/runtests.js
+++ b/data/runtests.js
@@ -3,7 +3,12 @@ iframe.contentDocument.body.setAttribute("spellcheck", "true");
 var content = iframe.contentDocument.body.innerHTML || "";
 
 var runTest = function(testObj) {
-  var contentTest = content.match(new RegExp(testObj.regex, 'gi')) || [];
+  var contentTest = [];
+  if (testObj.check) {
+    contentTest = testObj.check(content);
+  } else {
+    contentTest = content.match(new RegExp(testObj.regex, 'gi')) || [];
+  }
   testObj.count = contentTest.length;
   self.port.emit("test", testObj);
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,8 +1,6 @@
 const data = require("sdk/self").data;
 const tabs = require("sdk/tabs");
 
-var docTests = JSON.parse(data.load("doctests.js"));
-
 var sidebar = require("sdk/ui/sidebar").Sidebar({
   id: 'mdn-doc-tests',
   title: 'MDN documentation tester',
@@ -10,9 +8,9 @@ var sidebar = require("sdk/ui/sidebar").Sidebar({
   onReady: function (sbWorker) {
     sbWorker.port.on("runTests", function() {
       tabWorker = tabs.activeTab.attach({
-        contentScriptFile: data.url("runtests.js")
+        contentScriptFile: [data.url("doctests.js"), data.url("runtests.js")]
       });
-      tabWorker.port.emit("runTests", docTests);
+      tabWorker.port.emit("runTests");
       tabWorker.port.on("test", function(testObj){
         sbWorker.port.emit("test", testObj);
       });


### PR DESCRIPTION
This required to inject the doctests.js into the page content instead of providing them as `emit()` parameter, so a function `check()` could be added handling advanced checks.
