### PR TITLE
Fixed description of macroSyntaxError test

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -155,7 +155,7 @@ var docTests = [
   {
     id: "macroSyntaxError",
     name: "Macro syntax error",
-    desc: "A macro has a syntax error like a missing closing bracket, e.g. {{jsxref(\"Array\"}}.",
+    desc: "A macro has a syntax error like a missing closing bracket, e.g. {{jsxref('Array'}}.",
     check: function macroSyntaxErrorCheck(content) {
       function validateStringParams(macro) {
         var paramListStartIndex = macro.indexOf("(") + 1;


### PR DESCRIPTION
Otherwise a part of the description is missing in the tooltip.
