### PR TITLE
Add a test for line length in pre blocks to avoid scrollbars. Fixes #14.

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -293,5 +293,25 @@ var docTests = {
     },
     type: ERROR,
     count: 0
+  },
+
+  "preLineTooLong": {
+    name: "pre_line_too_long",
+    desc: "pre_line_too_long_desc",
+    check: function checkLineLengthInPre(content) {
+      var rePre = /<pre.*?>((?:.|\n)*?)<\/pre>/gi;
+      var errors = [];
+      var match = rePre.exec(content);
+      while (match) {
+        var codeBlocks = match[1].match(/^(?:[^\r\n]|\r(?!\n)){78,}$/gm);
+        if (codeBlocks) {
+          errors = errors.concat(codeBlocks);
+        }
+        match = rePre.exec(content);
+      }
+      return errors;
+    },
+    type: WARNING,
+    count: 0
   }
 };

--- a/locale/de.properties
+++ b/locale/de.properties
@@ -120,3 +120,9 @@ code_in_pre=&lt;code&gt; in &lt;pre&gt;
 
 # Description of test checking whether there are <code> tags within <pre> blocks
 code_in_pre_desc=&lt;code&gt; Tags sollten nicht innerhalb von &lt;pre&gt; Blöcken verwendet werden, weil sie die Syntaxhervorhebung verhindern.
+
+# Name of test checking whether there are too long lines within <pre> blocks
+pre_line_too_long=Zeilenlänge &gt;77 in &lt;pre&gt;
+
+# Description of test checking whether there are too long lines within <pre> blocks
+pre_line_too_long_desc=Um horizontale Scrollbalken zu verhinden, sollten maximal 77 Zeichen in einer Zeile in &lt;pre&gt; Blöcken vorhanden sein.

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -120,3 +120,9 @@ code_in_pre=&lt;code&gt; in &lt;pre&gt;
 
 # Description of test checking whether there are <code> tags within <pre> blocks
 code_in_pre_desc=&lt;code&gt; tags should not be used within &lt;pre&gt; blocks, because they break syntax highlighting.
+
+# Name of test checking whether there are too long lines within <pre> blocks
+pre_line_too_long=Line length &gt;77 in &lt;pre&gt;
+
+# Description of test checking whether there are too long lines within <pre> blocks
+pre_line_too_long_desc=To avoid horizontal scrollbars, there should be only 77 chars in &lt;pre&gt; blocks.

--- a/test/test-doctests.js
+++ b/test/test-doctests.js
@@ -192,4 +192,14 @@ exports["test doc codeInPre"] = function(assert) {
   assert.ok(test.length === 5, "test that <code> elements within <pre> blocks are matched");
 };
 
+exports["test doc preLineTooLong"] = function(assert) {
+  var str = '<pre>11111111111111111111111 11111111111111111111111 111111111111 111111111111111 1</pre>' +
+            '<pre class="brush:js">short\nstuff</pre>' +
+            '<pre class="brush:js">foo\nsome code\nbar<br>\n' +
+            'some code with\nline break\nbaz' +
+            '11111111111 111111111111 function{ foo(); 11111111111111 bar 1111111111111111 111</pre>';
+  var test = docTests["preLineTooLong"].check(str);
+  assert.ok(test.length === 2, "test that long lines within <pre> blocks are matched");
+};
+
 require("sdk/test").run(exports);


### PR DESCRIPTION
Turns out 78 is when scrollbars appear: https://developer.mozilla.org/en-US/docs/User:Elchi3/Sandbox
Maybe this should be a warning?

@SebastianZ r?
