### PR TITLE
Issue: Fixed test 'preWithoutClass' to also recognize 'class=""'

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -84,7 +84,22 @@ var docTests = {
   "preWithoutClass": {
     name: "pre_without_class",
     desc: "pre_without_class_desc",
-    regex: /(<pre(?=\s|>)(?!(?:[^>=]|=(['"])(?:(?!\1).)*\1)*?class=['"])[^>]*>[\S\s]*?<\/pre>)/gi,
+    check: function (content) {
+      var rePre = /<pre.*?>((?:.|[\r\n])*?)<\/pre>/gi;
+      var errors = [];
+      var match = rePre.exec(content);
+      while (match) {
+        if (!match[0].match(/^<pre[^>]*class=["'][^"']/)) {
+          errors = errors.concat(match[0]);
+        }
+
+        match = rePre.exec(content);
+      }
+
+      return errors.map(match => {
+        return {msg: match};
+      });
+    },
     type: ERROR,
     errors: []
   },

--- a/test/test-doctests.js
+++ b/test/test-doctests.js
@@ -135,17 +135,19 @@ exports["test doc regexp preWithoutClass"] = function(assert) {
               '<pre>foobar;</pre>' +
               '<pre class="syntaxbox"></pre>' +
               '<pre id="foo"></pre>' +
+              '<pre class="">foo</pre>' +
               '<pre> \n\r foo</pre>';
   const expected = [
     '<pre>foobar;</pre>',
     '<pre id="foo"></pre>',
+    '<pre class="">foo</pre>',
     '<pre> \n\r foo</pre>'
   ];
-  var matches = str.match(docTests["preWithoutClass"].regex);
+  var matches = docTests["preWithoutClass"].check(str);
 
   assert.equal(matches.length, expected.length, "Number of <pre> w/o class matches must be " + expected.length);
   matches.forEach((match, i) => {
-    assert.equal(match, expected[i], "Error message for <pre> w/o class match must be correct");
+    assert.equal(match.msg, expected[i], "Error message for <pre> w/o class match must be correct");
   });
 };
 


### PR DESCRIPTION
Empty classes (`class=""`) were missed by the `preWithoutClass` test. I replaced the regexp by a `check()` function.

Sebastian
