### PR TITLE
Issue 80: Updated tests to work on DOM instead of text

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -39,7 +39,7 @@ var docTests = {
           NodeFilter.SHOW_ELEMENT,
           {
             acceptNode: (node) => {
-              //alert(node.localName + ", " + node.textContent + ", " + node.localName.match(/^(?:link|track|param|area|command|col|base|meta|hr|source|img|keygen|br|wbr|input)$/i));
+              // matching self-closing elements and excluding them
               return !node.localName.match(/^(?:link|track|param|area|command|col|base|meta|hr|source|img|keygen|br|wbr|input)$/i) &&
                   node.textContent.match(/^(?:&nbsp;|\s|\n)*$/) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_CANCEL;
             }

--- a/data/runtests-simple.js
+++ b/data/runtests-simple.js
@@ -1,0 +1,13 @@
+// This test runner is called from unit tests only
+
+var testObj = docTests[self.options.name];
+var rootElement = document.createElement('div');
+var tests = JSON.parse(self.options.tests);
+
+tests.forEach(test => {
+  rootElement.innerHTML = test.str;
+  var matches = testObj.check(rootElement);
+  testObj.errors = matches;
+  testObj.expected = test.expected;
+  self.port.emit('testResult', testObj, self.options.name);
+});

--- a/data/runtests.js
+++ b/data/runtests.js
@@ -1,20 +1,19 @@
 var iframe = document.querySelectorAll("iframe.cke_wysiwyg_frame")[0];
 var content = "";
+var rootElement = null;
 if (iframe) {
   iframe.contentDocument.body.setAttribute("spellcheck", "true");
-  content = iframe.contentDocument.body.innerHTML || "";
+  rootElement = iframe.contentDocument.body;
 }
 
 var runTest = function(testObj, id) {
-  // If there's no content (e.g. happens when in source view),
-  // don't run the test suite
-  if (content === "") {
-    return;
+  // Only run the test suite if there's a root element
+  //(e.g. when in source view there's no root element set)
+  if (rootElement) {
+    var contentTest = testObj.check(rootElement);
+    testObj.errors = contentTest;
+    self.port.emit("test", testObj, id);
   }
-
-  var contentTest = testObj.check(content);
-  testObj.errors = contentTest;
-  self.port.emit("test", testObj, id);
 };
 
 self.port.on("runTests", function() {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "license": "MPL 2.0",
   "main": "lib/main.js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "icon": "resource://826e8996-b3c2-11e5-9f22-ba0be0483c18/data/icon.png",
   "preferences": [{
     "name": "autoExpandErrors",

--- a/test/test-doctests.js
+++ b/test/test-doctests.js
@@ -1,536 +1,586 @@
-var testFile = require("sdk/self").data.load("doctests.js");
+var data = require("sdk/self").data;
+var tabs = require("sdk/tabs");
 
-eval(testFile);
+const url = "https://developer.mozilla.org/en-US/";
 
-exports["test doc oldURLs"] = function(assert) {
-  const str = '<a href="/en/Web">Web</a><a href="/En/Mozilla">Mozilla</a>';
-  const expected = [
-    ' href="/en/Web"',
-    ' href="/En/Mozilla"'
-  ];
-  var matches = docTests["oldURLs"].check(str);
+function runTests(assert, done, name, desc, url, tests) {
+  tabs.open({
+    url: url,
+    onReady: tab => {
+      var worker = tabs.activeTab.attach({
+        contentScriptFile: [data.url("doctests.js")],
+        contentScript: "var testObj = docTests[self.options.name];" +
+                       "var rootElement = document.createElement('div');" +
+                       "var tests = JSON.parse(self.options.tests);" +
+                       "tests.forEach(test => {" +
+                       "  rootElement.innerHTML = test.str;" +
+                       "  var matches = testObj.check(rootElement);" +
+                       "  testObj.errors = matches;" +
+                       "  testObj.expected = test.expected;" +
+                       "  self.port.emit('testResult', testObj, self.options.name);" +
+                       "});",
+        contentScriptOptions: {"name": name, "tests": JSON.stringify(tests)}
+      });
 
-  assert.equal(matches.length, expected.length, "Number of '/en/' link matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for '/en/' link match must be correct");
+      var resultCount = 0;
+
+      worker.port.on("testResult", function(testObj) {
+        var matches = testObj.errors;
+        var expected = testObj.expected;
+        
+        //console.log(matches);
+        assert.equal(matches.length, expected.length, "Number of " + desc + " matches must be " + expected.length);
+        matches.forEach((match, i) => {
+          var expectedIsObject = typeof expected[i] === "object";
+          var expectedValue = expectedIsObject ? expected[i].msg : expected[i];
+          assert.equal(match.msg, expectedValue, "Error message for " + desc + " match must be correct");
+          if (expectedIsObject) {
+            assert.deepEqual(match.msgParams, expected[i].msgParams, "Error message params for " + desc + " match must be correct");
+          }
+        });
+        
+
+        resultCount++;
+        if (resultCount === tests.length) {
+          tabs.activeTab.close();
+          done();
+        }
+      });
+    }
   });
-};
+}
 
-exports["test doc emptyElements"] = function(assert) {
-  const str = '<p> </p>' +
-              '<p> \n\r </p>' +
-              '<p> &nbsp;</p>' +
-              '<p><br><br/></p>' +
-              '<img src="http://example.com/image.png">' +
-              '<input value="test"/>' +
-              '<p><span>some text</span></p>' +
-              '<p>some text</p>';
-  const expected = [
-    '<p> </p>',
-    '<p> \n\r </p>',
-    '<p> &nbsp;</p>',
-    '<p><br><br/></p>'
-  ];
-  var matches = docTests["emptyElements"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of empty element matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for empty element match must be correct");
-  });
-};
-
-exports["test doc languagesMacro"] = function(assert) {
-  const str = '{{ languages( { "ja": "Ja/Browser_chrome_tests" } ) }}';
-  const expected = [
-    '{{ languages( { "ja": "Ja/Browser_chrome_tests" } ) }}'
-  ];
-  var matches = docTests["languagesMacro"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of {{languages}} macro matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for {{languages}} macro match must be correct");
-  });
-};
-
-exports["test doc emptyBrackets"] = function(assert) {
-  const str = '{{ foo() }}' +
-              '{{bar()}}' +
-              '{{foobar("abc")}}' +
-              '{{baz}}';
-  const expected = [
-    '{{ foo() }}',
-    '{{bar()}}'
-  ];
-  var matches = docTests["emptyBrackets"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of empty brackets matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for empty brackets match must be correct");
-  });
-};
-
-exports["test doc styleAttribute"] = function(assert) {
-  const str = '<span style=""></span>' +
-              '<div style="margin-top:5%"></div>' +
-              '<section style="background:#fff; color: rgb(234, 234, 234);"></section>' +
-              '<b style=\'padding: 5px !important\'>test</b>' +
-              '<span style="font-family: \'Open Sans\', serif; line-height: 1.5"></span>';
-  const expected = [
-    'style=""',
-    'style="margin-top:5%"',
-    'style="background:#fff; color: rgb(234, 234, 234);"',
-    'style=\'padding: 5px !important\'',
-    'style="font-family: \'Open Sans\', serif; line-height: 1.5"'
-  ];
-  var matches = docTests["styleAttribute"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of 'style' attribute matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for 'style' attribute match must be correct");
-  });
-};
-
-exports["test doc nameAttribute"] = function(assert) {
-  const str = '<span name=""></span>' +
-              '<div name="foo"></div>' +
-              '<h2 id="foo" name="foo">foo</h2>' +
-              '<h2 id="foo_bar" name="foo_bar">foo bar</h2>' +
-              '<h3 name=\'baz\'>baz</h3>';
-  const expected = [
-    'name=""',
-    'name="foo"',
-    'name="foo"',
-    'name="foo_bar"',
-    'name=\'baz\''
-  ];
-  var matches = docTests["nameAttribute"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of 'name' attribute matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for 'name' attribute match must be correct");
-  });
-};
-
-exports["test doc spanCount"] = function(assert) {
-  const str = '<span>what?</span>' +
-              '<p>nope</p>' +
-              '<span class="foo" style="font:10px">bar</span>' +
-              '<span><dt>foobar</dt></span>' +
-              '<span class="seoSummary">seoseoseo</span>';
-  const expected = [
-    '<span>what?</span>',
-    '<span class="foo" style="font:10px">bar</span>',
-    '<span><dt>foobar</dt></span>'
-  ];
-  var matches = docTests["spanCount"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of <span> matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for <span> match must be correct");
-  });
-};
-
-exports["test doc preWithoutClass"] = function(assert) {
-  const str = '<pre class="brush: js"></pre>' +
-              '<pre>foobar;</pre>' +
-              '<pre class="syntaxbox"></pre>' +
-              '<pre id="foo"></pre>' +
-              '<pre class="">foo</pre>' +
-              '<pre> \n\r foo</pre>';
-  const expected = [
-    '<pre>foobar;</pre>',
-    '<pre id="foo"></pre>',
-    '<pre class="">foo</pre>',
-    '<pre> \n\r foo</pre>'
-  ];
-  var matches = docTests["preWithoutClass"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of <pre> w/o class matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for <pre> w/o class match must be correct");
-  });
-};
-
-exports["test doc summaryHeading"] = function(assert) {
-  const str = '<h2>Summary</h2>' +
-              '<h2 id="Summary" name="Summary">Summary</h2>' +
-              '<h2 id="Summary" name="foo">Summary</h2>' +
-              '<h3 id="Summary">Summary</h3>';
-  const expected = [
-    '<h2>Summary</h2>',
-    '<h2 id="Summary" name="Summary">Summary</h2>',
-    '<h2 id="Summary" name="foo">Summary</h2>',
-    '<h3 id="Summary">Summary</h3>'
-  ];
-  var matches = docTests["summaryHeading"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of summary heading matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for summary heading match must be correct");
-  });
-};
-
-exports["test doc jsRefWithParams"] = function(assert) {
-  const str = '{{JSRef()}}' +
-              '{{JSRef("Global_Objects")}}' +
-              '{{JSRef("Global_Objects", "Math")}}' +
-              '{{JSRef}}';
-  const expected = [
-    '{{JSRef()}}',
-    '{{JSRef("Global_Objects")}}',
-    '{{JSRef("Global_Objects", "Math")}}'
-  ];
-  var matches = docTests["jsRefWithParams"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of {{JSRef}} with params matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for {{JSRef}} with params match must be correct");
-  });
-};
-
-exports["test doc exampleColonHeading"] = function(assert) {
-  const str = '<h2>Example</h2>' +
-              '<h3 id="Example">Example</h3>' +
-              '<h3 id="Example:_Foo">Example: Foo</h3>' +
-              '<h3 id="Example:_Using_Math.sin">Example: Using <code>Math.sin</code></h3>' +
-              '<h2 id="Example:_Foo">Example: Foo</h2>';
-  const expected = [
-    '<h3 id="Example:_Foo">Example: Foo</h3>',
-    '<h3 id="Example:_Using_Math.sin">Example: Using <code>Math.sin</code></h3>',
-    '<h2 id="Example:_Foo">Example: Foo</h2>'
-  ];
-  var matches = docTests["exampleColonHeading"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of 'Example: ' heading matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for 'Example: ' heading match must be correct");
-  });
-};
-
-exports["test doc alertPrintInCode"] = function(assert) {
-  const str = '<pre>alert("foo")</pre>' +
-              '<pre class="syntaxbox">print("bar")</pre>' +
-              '<pre>var someOthercode = baz; ' +
-              'alert("hello world"); \n var moreCode;</pre>' +
-              '<pre>document.write("foobar");</pre>';
-  const expected = [
-    'alert("foo")',
-    'print("bar")',
-    'alert("hello world")',
-    'document.write("foobar")'
-  ];
-  var matches = docTests["alertPrintInCode"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of alert()/print()/eval()/document.write() matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for alert()/print()/eval()/document.write() match must be correct");
-  });
-};
-
-exports["test doc htmlComments"] = function(assert) {
-  const str = '<!-- -->' +
-              '<!-- <span>foo</span> -->' +
-              '<!-- hello \n world -->';
-  const expected = [
-    '<!-- -->',
-    '<!-- <span>foo</span> -->',
-    '<!-- hello \n world -->'
-  ];
-  var matches = docTests["htmlComments"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of HTML comment matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for HTML comment match must be correct");
-  });
-};
-
-exports["test doc fontElements"] = function(assert) {
-  const str = '<font>' +
-              '<font face="Open Sans, sans-serif">';
-  const expected = [
-    '<font>',
-    '<font face="Open Sans, sans-serif">'
-  ];
-  var matches = docTests["fontElements"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of <font> matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for <font> match must be correct");
-  });
-};
-
-exports["test doc httpLinks"] = function(assert) {
-  const str = '<a href="https://somepage.com">some page</a>' +
-              '<a href="ftp://somepage.com">some page</a>' +
-              '<a href="https://somepage.com?url=http://anotherpage.com">some page</a>' +
-              '<a href="http://somepage.com">some page</a>';
-  const expected = [
-    '<a href="http://'
-  ];
-  var matches = docTests["httpLinks"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of HTTP link matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for HTTP link match must be correct");
-  });
-};
-
-exports["test doc macroSyntaxError"] = function(assert) {
-  const str = '{{macro}}' +
-              '{{ macro }}' +
-              '{{macro("param")}}' +
-              '{{ macro("param") }}' +
-              '{{macro(123)}}' +
-              '{{macro(123, "param")}}' +
-              '{{macro(\'param\', 123, "param")}}' +
-              '{{macro("param)}}' + // Missing closing double quote
-              '{{macro(\'param)}}' + // Missing closing single quote
-              '{{macro(param)}}' + // Missing quotes
-              '{{macro(param")}}' + // Missing opening double quote
-              '{{macro(param\')}}' + // Missing opening single quote
-              '{{macro(\'param\', 123, "param)}}' + // Missing closing double quote, multiple parameters
-              '{{macro("param"))}}' + // Double closing parameter list bracket
-              '{{macro("param")}' + // Missing closing macro curly brace after double quoted parameter
-              '{{macro(\'param\')}' + // Missing closing macro curly brace after single quoted parameter
-              '{{macro("param"}}' + // Missing closing parameter list bracket after double quoted parameter
-              '{{macro(\'param\'}}' + // Missing closing parameter list bracket after single quoted parameter
-              '{{macro(param"}}' + // Missing opening double quote and missing closing parameter list bracket
-              '{{macro(param"))}}'; // Missing opening double quote and double closing parameter list bracket
-  const expected = [
+exports["test doc oldURLs"] = function testOldURLs(assert, done) {
+  const tests = [
     {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ['{{macro("param)}}']
-    },
-    {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ["{{macro('param)}}"]
-    },
-    {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ["{{macro(param)}}"]
-    },
-    {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ['{{macro(param")}}']
-    },
-    {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ["{{macro(param')}}"]
-    },
-    {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ["{{macro('param', 123, \"param)}}"]
-    },
-    {
-      msg: "additional_closing_bracket",
-      msgParams: ['{{macro("param"))}}']
-    },
-    {
-      msg: "missing_closing_curly_brace",
-      msgParams: ['{{macro("param")}']
-    },
-    {
-      msg: "missing_closing_curly_brace",
-      msgParams: ["{{macro(\'param\')}"]
-    },
-    {
-      msg: "missing_closing_bracket",
-      msgParams: ['{{macro("param"}}']
-    },
-    {
-      msg: "missing_closing_bracket",
-      msgParams: ["{{macro(\'param\'}}"]
-    },
-    {
-      msg: "missing_closing_bracket",
-      msgParams: ['{{macro(param"}}']
-    },
-    {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ['{{macro(param"}}']
-    },
-    {
-      msg: "string_parameter_incorrectly_quoted",
-      msgParams: ['{{macro(param"))}}']
-    },
-    {
-      msg: "additional_closing_bracket",
-      msgParams: ['{{macro(param"))}}']
+      str: '<a href=\"/en/Web\">Web</a>' +
+           '<a href=\"/En/Mozilla\">Mozilla</a>',
+      expected: [
+        '<a href=\"/en/Web\">Web</a>',
+        '<a href=\"/En/Mozilla\">Mozilla</a>'
+      ]
     }
   ];
-  var matches = docTests["macroSyntaxError"].check(str);
 
-  assert.equal(matches.length, expected.length, "Number of macro syntax error matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i].msg, "Error message for macro syntax error match must be correct");
-    assert.deepEqual(match.msgParams, expected[i].msgParams, "Error message params for macro syntax error match must be correct");
-  });
+  runTests(assert, done, "oldURLs", "'/en/' link", url, tests);
 };
 
-exports["test doc wrongHighlightedLine"] = function(assert) {
-  const str = '<pre class="brush: js; highlight[2];">foo\nbar</pre>' +
-              '<pre class="brush:js;">foo\nbar</pre>' +
-              '<pre class="highlight[1]; brush:js;">foo\nbar</pre>' +
-              '<pre class="brush: js; highlight[1,3];"foo\nbar\nbaz</pre>' +
-              '<pre class="brush: js; highlight[1-3];"foo\nbar\nbaz</pre>' +
-              '<pre class="brush: js; highlight[1-3,5];"foo\nbar\nbaz\nbax\nbix</pre>' + +
-              '<pre class="brush: js; highlight[ 1, 3 - 5 ,2 ];"foo\nbar\nbaz\nbax\nbix</pre>' +
-              '<pre class="brush: js; highlight[0];">foo\nbar</pre>' +
-              '<pre class="brush: js; highlight[-1];">foo\nbar</pre>' +
-              '<pre class="brush: js; highlight[3];">foo\nbar</pre>' +
-              '<pre class="brush: js; highlight[3];">foo<br>bar</pre>' +
-              '<pre class="brush: js; highlight[3];">foo<br/>bar</pre>' +
-              '<pre class="brush: js; highlight:[3];">foo<br>bar</pre>' +
-              '<pre class="brush: js; highlight[1,-3--5,3];">foo\nbar\nbaz</pre>' +
-              '<pre class="brush: js; highlight [ 1, 3 - 6 ,2 ];">foo\nbar\nbaz</pre>';
-  const expected = [
+exports["test doc emptyElements"] = function testEmptyElements(assert, done) {
+  const tests = [
     {
-      msg: "highlighted_line_number_not_positive",
-      msgParams: ["0", "0"]
-    },
-    {
-      msg: "highlighted_line_number_not_positive",
-      msgParams: ["-1", "-1"]
-    },
-    {
-      msg: "highlighted_line_number_too_big",
-      msgParams: ["3", "2", "3"]
-    },
-    {
-      msg: "highlighted_line_number_too_big",
-      msgParams: ["3", "2", "3"]
-    },
-    {
-      msg: "highlighted_line_number_too_big",
-      msgParams: ["3", "2", "3"]
-    },
-    {
-      msg: "highlighted_line_number_too_big",
-      msgParams: ["3", "2", "3"]
-    },
-    {
-      msg: "highlighted_line_number_not_positive",
-      msgParams: ["-3", "1,-3--5,3"]
-    },
-    {
-      msg: "highlighted_line_number_not_positive",
-      msgParams: ["-5", "1,-3--5,3"]
-    },
-    {
-      msg: "invalid_highlighted_range",
-      msgParams: ["-3", "-5", "1,-3--5,3"]
-    },
-    {
-      msg: "highlighted_line_number_too_big",
-      msgParams: ["6", "3", " 1, 3 - 6 ,2 "]
+      str: '<p> </p>' +
+           '<p> \n\r </p>' +
+           '<p> &nbsp;</p>' +
+           '<p><br><br/></p>' +
+           '<img src="http://example.com/image.png">' +
+           '<input value="test"/>' +
+           '<p><span>some text</span></p>' +
+           '<p>some text</p>',
+      expected: [
+        '<p> </p>',
+        '<p> \n\n </p>',
+        '<p> &nbsp;</p>',
+        '<p><br><br></p>'
+      ]
     }
   ];
-  var matches = docTests["wrongHighlightedLine"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of wrong highlighted line matches must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i].msg, "Error message for wrong highlighted line match must be correct");
-    assert.deepEqual(match.msgParams, expected[i].msgParams, "Error message params for wrong highlighted line match must be correct");
-  });
+  
+  runTests(assert, done, "emptyElements", "empty elements", url, tests);
 };
 
-exports["test doc apiSyntaxHeadlines"] = function(assert) {
-  const str = '<h2 id="Syntax">Syntax</h2>' +
-              '<h3>Errors</h3>' +
-              '<h3>Returns</h3>' +
-              '<h3>Parameters</h3>';
-  const expected = [
+exports["test doc languagesMacro"] = function testEmptyElements(assert, done) {
+  const tests = [
     {
-      msg: "invalid_headline_name",
-      msgParams: ["Errors"]
-    },
-    {
-      msg: "invalid_headline_name",
-      msgParams: ["Returns"]
-    },
-    {
-      msg: "invalid_headline_order",
-    },
-    {
-      msg: "invalid_headline_order",
+      str: '{{ languages( { "ja": "Ja/Browser_chrome_tests" } ) }}',
+      expected: [
+        '{{ languages( { "ja": "Ja/Browser_chrome_tests" } ) }}'
+      ]
     }
   ];
-  var matches = docTests["apiSyntaxHeadlines"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of API syntax headline errors must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i].msg, "Error message for API syntax headline errors must be correct");
-    assert.deepEqual(match.msgParams, expected[i].msgParams, "Error message params for API syntax headline errors must be correct");
-  });
+  
+  runTests(assert, done, "languagesMacro", "{{languages}} macro", url, tests);
 };
 
-exports["test doc codeInPre"] = function(assert) {
-  const str = '<pre>no code</pre>' +
-              '<pre class="brush:js">no code</pre>' +
-              '<pre class="brush:js"><code>some code</code></pre>' +
-              '<pre class="brush:js"><code>some code</code><code>some more inline code</code></pre>' +
-              '<pre class="brush:js">foo\n<code>some code</code>\nbar<br>\n<code>some code with\nline break</code>\nbaz</pre>';
-  const expected = [
-    '<code>some code</code>',
-    '<code>some code</code>',
-    '<code>some more inline code</code>',
-    '<code>some code</code>',
-    '<code>some code with\nline break</code>'
-  ];
-  var matches = docTests["codeInPre"].check(str);
-
-  assert.equal(matches.length, expected.length, "Number of <code> in <pre> errors must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for <code> in <pre> errors must be correct");
-  });
-};
-
-exports["test doc wrongSyntaxClass"] = function(assert) {
-  const strs = [
-    'foo<h2>Syntax</h2>\n<pre class="syntaxbox">syntax</pre>bar',
-    'foo<h2>Syntax</h2>\n<pre class="brush:css">syntax examples</pre>bar<h3>Formal syntax</h3>\n<pre class"syntaxbox">syntax</pre>',
-    'foo<h2>Syntax</h2>\n<pre class="brush:js">syntax</pre>bar',
-    'foo<h2>Syntax</h2>\n<pre class="brush:css">syntax examples</pre>bar<h3>Formal syntax</h3>\n<pre class="eval">syntax</pre>baz<h2>Other section</h2>'
-  ];
-  const expected = [
+exports["test doc emptyBrackets"] = function testEmptyBrackets(assert, done) {
+  const tests = [
     {
-      msg: "wrong_syntax_class_used",
-      msgParams: ["brush:js"]
-    },
-    {
-      msg: "wrong_syntax_class_used",
-      msgParams: ["eval"]
+      str: '{{ foo() }}' +
+           '{{bar()}}' +
+           '{{foobar("abc")}}' +
+           '{{baz}}',
+      expected: [
+        '{{ foo() }}',
+        '{{bar()}}'
+      ]
     }
   ];
-  var matches = [];
-  strs.forEach(str => {
-    matches = matches.concat(docTests["wrongSyntaxClass"].check(str));
-  })
-
-  assert.equal(matches.length, expected.length, "Number of wrong syntax box class errors must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i].msg, "Error message for wrong syntax box class errors must be correct");
-    assert.deepEqual(match.msgParams, expected[i].msgParams, "Error message params for wrong syntax box class errors must be correct");
-  });
+  
+  runTests(assert, done, "emptyBrackets", "empty brackets", url, tests);
 };
 
-exports["test doc lineLengthInPre"] = function(assert) {
-  const str = '<pre>11111111111111111111111 11111111111111111111111 111111111111 111111111111111 1</pre>' +
-              '<pre>11111111111111111111111 11111111111111111111111<br> 111111111111 111111111111111 1</pre>' +
-              '<pre class="brush:js">short\nstuff</pre>' +
-              '<pre class="brush:js">foo\nsome code\nbar<br>\n' +
-              'some code with\nline break\nbaz' +
-              '11111111111 111111111111 function{ foo(); 11111111111111 bar 1111111111111111 111</pre>';
-  const expected = [
-    '11111111111111111111111 11111111111111111111111 111111111111 111111111111111 1',
-    'baz11111111111 111111111111 function{ foo(); 11111111111111 bar 1111111111111111 111'
+exports["test doc styleAttribute"] = function testStyleAttributes(assert, done) {
+  const tests = [
+    {
+      str: '<span style=""></span>' +
+           '<div style="margin-top:5%"></div>' +
+           '<section style="background:#fff; color: rgb(234, 234, 234);"></section>' +
+           '<b style=\'padding: 5px !important\'>test</b>' +
+           '<span style="font-family: \'Open Sans\', serif; line-height: 1.5"></span>',
+      expected: [
+        'style=""',
+        'style="margin-top:5%"',
+        'style="background:#fff; color: rgb(234, 234, 234);"',
+        'style="padding: 5px !important"',
+        'style="font-family: \'Open Sans\', serif; line-height: 1.5"'
+      ]
+    }
   ];
-  var matches = docTests["lineLengthInPre"].check(str);
+  
+  runTests(assert, done, "styleAttribute", "'style' attribute", url, tests);
+};
 
-  assert.equal(matches.length, expected.length, "Number of too long line in <pre> errors must be " + expected.length);
-  matches.forEach((match, i) => {
-    assert.equal(match.msg, expected[i], "Error message for too long line in <pre> errors must be correct");
-  });
+exports["test doc nameAttribute"] = function testNameAttributes(assert, done) {
+  const tests = [
+    {
+      str: '<span name=""></span>' +
+           '<div name="foo"></div>' +
+           '<h2 id="foo" name="foo">foo</h2>' +
+           '<h2 id="foo_bar" name="foo_bar">foo bar</h2>' +
+           '<h3 name=\'baz\'>baz</h3>',
+      expected: [
+        'name=""',
+        'name="foo"',
+        'name="foo"',
+        'name="foo_bar"',
+        'name="baz"'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "nameAttribute", "'name' attribute", url, tests);
+};
+
+exports["test doc spanCount"] = function testSpanElements(assert, done) {
+  const tests = [
+    {
+      str: '<span>what?</span>' +
+           '<p>nope</p>' +
+           '<span class="foo" style="font:10px">bar</span>' +
+           '<span><dt>foobar</dt></span>' +
+           '<span class="seoSummary">seoseoseo</span>',
+      expected: [
+        '<span>what?</span>',
+        '<span class="foo" style="font:10px">bar</span>',
+        '<span><dt>foobar</dt></span>'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "spanCount", "<span>", url, tests);
+};
+
+exports["test doc preWithoutClass"] = function testPresWithoutClass(assert, done) {
+  const tests = [
+    {
+      str: '<pre class="brush: js"></pre>' +
+           '<pre>foobar;</pre>' +
+           '<pre class="syntaxbox"></pre>' +
+           '<pre id="foo"></pre>' +
+           '<pre class="">foo</pre>' +
+           '<pre> \n\r foo</pre>',
+      expected: [
+        '<pre>foobar;</pre>',
+        '<pre id="foo"></pre>',
+        '<pre class="">foo</pre>',
+        '<pre> \n\n foo</pre>'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "preWithoutClass", "<pre> w/o class", url, tests);
+};
+
+exports["test doc summaryHeading"] = function testSummaryHeading(assert, done) {
+  const tests = [
+    {
+      str: '<h2>Summary</h2>' +
+           '<h2 id="Summary" name="Summary">Summary</h2>' +
+           '<h2 id="Summary" name="foo">Summary</h2>' +
+           '<h3 id="Summary">Summary</h3>',
+      expected: [
+        '<h2>Summary</h2>',
+        '<h2 id="Summary" name="Summary">Summary</h2>',
+        '<h2 id="Summary" name="foo">Summary</h2>',
+        '<h3 id="Summary">Summary</h3>'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "summaryHeading", "summary heading", url, tests);
+};
+
+exports["test doc jsRefWithParams"] = function testJSRefWithParams(assert, done) {
+  const tests = [
+    {
+      str: '{{JSRef()}}' +
+           '{{JSRef("Global_Objects")}}' +
+           '{{JSRef("Global_Objects", "Math")}}' +
+           '{{JSRef}}',
+      expected: [
+        '{{JSRef()}}',
+        '{{JSRef("Global_Objects")}}',
+        '{{JSRef("Global_Objects", "Math")}}'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "jsRefWithParams", "{{JSRef}} with params", url, tests);
+};
+
+exports["test doc exampleColonHeading"] = function testExampleColonHeading(assert, done) {
+  const tests = [
+    {
+      str: '<h2>Example</h2>' +
+           '<h3 id="Example">Example</h3>' +
+           '<h3 id="Example:_Foo">Example: Foo</h3>' +
+           '<h3 id="Example:_Using_Math.sin">Example: Using <code>Math.sin</code></h3>' +
+           '<h2 id="Example:_Foo">Example: Foo</h2>',
+      expected: [
+        '<h3 id="Example:_Foo">Example: Foo</h3>',
+        '<h3 id="Example:_Using_Math.sin">Example: Using <code>Math.sin</code></h3>',
+        '<h2 id="Example:_Foo">Example: Foo</h2>'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "exampleColonHeading", "'Example: ' heading", url, tests);
+};
+
+exports["test doc alertPrintInCode"] = function testAlertPrintInCode(assert, done) {
+  const tests = [
+    {
+      str: '<pre>alert("foo")</pre>' +
+           '<pre class="syntaxbox">print("bar")</pre>' +
+           '<pre>var someOthercode = baz; ' +
+           'alert("hello world"); \n var moreCode;</pre>' +
+           '<pre>document.write("foobar");</pre>',
+      expected: [
+        'alert("foo")',
+        'print("bar")',
+        'alert("hello world")',
+        'document.write("foobar")'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "alertPrintInCode", "alert()/print()/eval()/document.write()", url, tests);
+};
+
+exports["test doc htmlComments"] = function testHTMLComments(assert, done) {
+  const tests = [
+    {
+      str: '<!-- -->' +
+           '<!-- <span>foo</span> -->' +
+           '<!-- hello \n world -->',
+      expected: [
+        '<!-- -->',
+        '<!-- <span>foo</span> -->',
+        '<!-- hello \n world -->'
+      ]
+    }
+  ];
+
+  runTests(assert, done, "htmlComments", "HTML comment", url, tests);
+};
+
+exports["test doc fontElements"] = function testFontElements(assert, done) {
+  const tests = [
+    {
+      str: '<font>Some text</font>' +
+           '<font face="Open Sans, sans-serif">Another text</font>',
+      expected: [
+        '<font>Some text</font>',
+        '<font face="Open Sans, sans-serif">Another text</font>'
+      ] 
+    }
+  ];
+
+  runTests(assert, done, "fontElements", "<font>", url, tests);
+};
+
+exports["test doc httpLinks"] = function testHTTPLinks(assert, done) {
+  const tests = [
+    {
+      str: '<a href=\"https://somepage.com\">some page</a>' +
+           '<a href=\"ftp://somepage.com\">some page</a>' +
+           '<a href=\"https://somepage.com?url=http://anotherpage.com\">some page</a>' +
+           '<a href=\"http://somepage.com\">some page</a>',
+      expected: [
+        '<a href="http://somepage.com">some page</a>'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "httpLinks", "HTTP link", url, tests);
+};
+
+exports["test doc macroSyntaxError"] = function testMacroSyntaxErrors(assert, done) {
+  const tests = [
+    {
+      str: '{{macro}}' +
+           '{{ macro }}' +
+           '{{macro("param")}}' +
+           '{{ macro("param") }}' +
+           '{{macro(123)}}' +
+           '{{macro(123, "param")}}' +
+           '{{macro(\'param\', 123, "param")}}' +
+           '{{macro("param)}}' + // Missing closing double quote
+           '{{macro(\'param)}}' + // Missing closing single quote
+           '{{macro(param)}}' + // Missing quotes
+           '{{macro(param")}}' + // Missing opening double quote
+           '{{macro(param\')}}' + // Missing opening single quote
+           '{{macro(\'param\', 123, "param)}}' + // Missing closing double quote, multiple parameters
+           '{{macro("param"))}}' + // Double closing parameter list bracket
+           '{{macro("param")}' + // Missing closing macro curly brace after double quoted parameter
+           '{{macro(\'param\')}' + // Missing closing macro curly brace after single quoted parameter
+           '{{macro("param"}}' + // Missing closing parameter list bracket after double quoted parameter
+           '{{macro(\'param\'}}' + // Missing closing parameter list bracket after single quoted parameter
+           '{{macro(param"}}' + // Missing opening double quote and missing closing parameter list bracket
+           '{{macro(param"))}}', // Missing opening double quote and double closing parameter list bracket
+      expected: [
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ['{{macro("param)}}']
+        },
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ["{{macro('param)}}"]
+        },
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ["{{macro(param)}}"]
+        },
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ['{{macro(param")}}']
+        },
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ["{{macro(param')}}"]
+        },
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ["{{macro('param', 123, \"param)}}"]
+        },
+        {
+          msg: "additional_closing_bracket",
+          msgParams: ['{{macro("param"))}}']
+        },
+        {
+          msg: "missing_closing_curly_brace",
+          msgParams: ['{{macro("param")}']
+        },
+        {
+          msg: "missing_closing_curly_brace",
+          msgParams: ["{{macro(\'param\')}"]
+        },
+        {
+          msg: "missing_closing_bracket",
+          msgParams: ['{{macro("param"}}']
+        },
+        {
+          msg: "missing_closing_bracket",
+          msgParams: ["{{macro(\'param\'}}"]
+        },
+        {
+          msg: "missing_closing_bracket",
+          msgParams: ['{{macro(param"}}']
+        },
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ['{{macro(param"}}']
+        },
+        {
+          msg: "string_parameter_incorrectly_quoted",
+          msgParams: ['{{macro(param"))}}']
+        },
+        {
+          msg: "additional_closing_bracket",
+          msgParams: ['{{macro(param"))}}']
+        }
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "macroSyntaxError", "macro syntax error", url, tests);
+};
+
+exports["test doc wrongHighlightedLine"] = function testWrongHighlightedLines(assert, done) {
+  const tests = [
+    {
+      str: '<pre class="brush: js; highlight[2];">foo\nbar</pre>' +
+           '<pre class="brush:js;">foo\nbar</pre>' +
+           '<pre class="highlight[1]; brush:js;">foo\nbar</pre>' +
+           '<pre class="brush: js; highlight[1,3];"foo\nbar\nbaz</pre>' +
+           '<pre class="brush: js; highlight[1-3];"foo\nbar\nbaz</pre>' +
+           '<pre class="brush: js; highlight[1-3,5];"foo\nbar\nbaz\nbax\nbix</pre>' + +
+           '<pre class="brush: js; highlight[ 1, 3 - 5 ,2 ];"foo\nbar\nbaz\nbax\nbix</pre>' +
+           '<pre class="brush: js; highlight[0];">foo\nbar</pre>' +
+           '<pre class="brush: js; highlight[-1];">foo\nbar</pre>' +
+           '<pre class="brush: js; highlight[3];">foo\nbar</pre>' +
+           '<pre class="brush: js; highlight[3];">foo<br>bar</pre>' +
+           '<pre class="brush: js; highlight[3];">foo<br/>bar</pre>' +
+           '<pre class="brush: js; highlight:[3];">foo<br>bar</pre>' +
+           '<pre class="brush: js; highlight[1,-3--5,3];">foo\nbar\nbaz</pre>' +
+           '<pre class="brush: js; highlight [ 1, 3 - 6 ,2 ];">foo\nbar\nbaz</pre>',
+      expected: [
+        {
+          msg: "highlighted_line_number_not_positive",
+          msgParams: ["0", "0"]
+        },
+        {
+          msg: "highlighted_line_number_not_positive",
+          msgParams: ["-1", "-1"]
+        },
+        {
+          msg: "highlighted_line_number_too_big",
+          msgParams: ["3", "2", "3"]
+        },
+        {
+          msg: "highlighted_line_number_too_big",
+          msgParams: ["3", "2", "3"]
+        },
+        {
+          msg: "highlighted_line_number_too_big",
+          msgParams: ["3", "2", "3"]
+        },
+        {
+          msg: "highlighted_line_number_too_big",
+          msgParams: ["3", "2", "3"]
+        },
+        {
+          msg: "highlighted_line_number_not_positive",
+          msgParams: ["-3", "1,-3--5,3"]
+        },
+        {
+          msg: "highlighted_line_number_not_positive",
+          msgParams: ["-5", "1,-3--5,3"]
+        },
+        {
+          msg: "invalid_highlighted_range",
+          msgParams: ["-3", "-5", "1,-3--5,3"]
+        },
+        {
+          msg: "highlighted_line_number_too_big",
+          msgParams: ["6", "3", " 1, 3 - 6 ,2 "]
+        }
+      ]
+    }
+  ];
+
+  runTests(assert, done, "wrongHighlightedLine", "wrong highlighted line", url, tests);
+};
+
+exports["test doc apiSyntaxHeadlines"] = function testSummaryHeading(assert, done) {
+  const tests = [
+    {
+      str: '<h2 id="Syntax">Syntax</h2>' +
+           '<h3>Errors</h3>' +
+           '<h3>Returns</h3>' +
+           '<h3>Parameters</h3>',
+      expected: [
+        {
+          msg: "invalid_headline_name",
+          msgParams: ["Errors"]
+        },
+        {
+          msg: "invalid_headline_name",
+          msgParams: ["Returns"]
+        },
+        {
+          msg: "invalid_headline_order",
+        },
+        {
+          msg: "invalid_headline_order",
+        }
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "apiSyntaxHeadlines", "API syntax headline", url, tests);
+};
+
+exports["test doc codeInPre"] = function testSummaryHeading(assert, done) {
+  const tests = [
+    {
+      str: '<pre>no code</pre>' +
+           '<pre class="brush:js">no code</pre>' +
+           '<pre class="brush:js"><code>some code</code></pre>' +
+           '<pre class="brush:js"><code>some code</code><code>some more inline code</code></pre>' +
+           '<pre class="brush:js">foo\n<code>some code</code>\nbar<br>\n<code>some code with\nline break</code>\nbaz</pre>',
+      expected: [
+        '<code>some code</code>',
+        '<code>some code</code>',
+        '<code>some more inline code</code>',
+        '<code>some code</code>',
+        '<code>some code with\nline break</code>'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "codeInPre", "<code> in <pre>", url, tests);
+};
+
+exports["test doc wrongSyntaxClass"] = function testWrongSyntaxClass(assert, done) {
+  const tests = [
+    {
+      str: 'foo<h2>Syntax</h2>\\n<pre class=\"syntaxbox\">syntax</pre>bar',
+      expected: []
+    },
+    {
+      str: 'foo<h2>Syntax</h2>\\n<pre class=\"brush:css\">syntax examples</pre>bar<h3>Formal syntax</h3>\\n<pre class=\"syntaxbox\">syntax</pre>',
+      expected: []
+    },
+    {
+      str: 'foo<h2>Syntax</h2>\\n<pre class=\"brush:js\">syntax</pre>bar',
+      expected: [
+        {
+          msg: "wrong_syntax_class_used",
+          msgParams: ["brush:js"]
+        }
+      ]
+    },
+    {
+      str: 'foo<h2>Syntax</h2>\\n<pre class=\"brush:css\">syntax examples</pre>bar<h3>Formal syntax</h3>\\n<pre class=\"eval\">syntax</pre>baz<h2>Other section</h2>',
+      expected: [
+        {
+          msg: "wrong_syntax_class_used",
+          msgParams: ["eval"]
+        }
+      ]
+    }
+  ];
+
+  runTests(assert, done, "wrongSyntaxClass", "syntax box class", url, tests);
+};
+
+exports["test doc lineLengthInPre"] = function testSummaryHeading(assert, done) {
+  const tests = [
+    {
+      str: '<pre>11111111111111111111111 11111111111111111111111 111111111111 111111111111111 1</pre>' +
+           '<pre>11111111111111111111111 11111111111111111111111<br> 111111111111 111111111111111 1</pre>' +
+           '<pre class="brush:js">short\nstuff</pre>' +
+           '<pre class="brush:js">foo\nsome code\nbar<br>\n' +
+           'some code with\nline break\nbaz' +
+           '11111111111 111111111111 function{ foo(); 11111111111111 bar 1111111111111111 111</pre>',
+      expected: [
+        '11111111111111111111111 11111111111111111111111 111111111111 111111111111111 1',
+        'baz11111111111 111111111111 function{ foo(); 11111111111111 bar 1111111111111111 111'
+      ]
+    }
+  ];
+  
+  runTests(assert, done, "lineLengthInPre", "too long line", url, tests);
 };
 
 require("sdk/test").run(exports);

--- a/test/test-doctests.js
+++ b/test/test-doctests.js
@@ -1,24 +1,14 @@
 var data = require("sdk/self").data;
 var tabs = require("sdk/tabs");
 
-const url = "https://developer.mozilla.org/en-US/";
+const url = "about:blank";
 
 function runTests(assert, done, name, desc, url, tests) {
   tabs.open({
     url: url,
     onReady: tab => {
       var worker = tabs.activeTab.attach({
-        contentScriptFile: [data.url("doctests.js")],
-        contentScript: "var testObj = docTests[self.options.name];" +
-                       "var rootElement = document.createElement('div');" +
-                       "var tests = JSON.parse(self.options.tests);" +
-                       "tests.forEach(test => {" +
-                       "  rootElement.innerHTML = test.str;" +
-                       "  var matches = testObj.check(rootElement);" +
-                       "  testObj.errors = matches;" +
-                       "  testObj.expected = test.expected;" +
-                       "  self.port.emit('testResult', testObj, self.options.name);" +
-                       "});",
+        contentScriptFile: ["./doctests.js", "./runtests-simple.js"],
         contentScriptOptions: {"name": name, "tests": JSON.stringify(tests)}
       });
 
@@ -27,18 +17,22 @@ function runTests(assert, done, name, desc, url, tests) {
       worker.port.on("testResult", function(testObj) {
         var matches = testObj.errors;
         var expected = testObj.expected;
-        
-        //console.log(matches);
-        assert.equal(matches.length, expected.length, "Number of " + desc + " matches must be " + expected.length);
+
+        assert.equal(matches.length, expected.length,
+                     "Number of " + desc + " matches must be " + expected.length);
+
         matches.forEach((match, i) => {
           var expectedIsObject = typeof expected[i] === "object";
           var expectedValue = expectedIsObject ? expected[i].msg : expected[i];
-          assert.equal(match.msg, expectedValue, "Error message for " + desc + " match must be correct");
+
+          assert.equal(match.msg, expectedValue,
+                       "Error message for " + desc + " match must be correct");
+
           if (expectedIsObject) {
-            assert.deepEqual(match.msgParams, expected[i].msgParams, "Error message params for " + desc + " match must be correct");
+            assert.deepEqual(match.msgParams, expected[i].msgParams,
+                             "Error message params for " + desc + " match must be correct");
           }
         });
-        
 
         resultCount++;
         if (resultCount === tests.length) {
@@ -84,7 +78,7 @@ exports["test doc emptyElements"] = function testEmptyElements(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "emptyElements", "empty elements", url, tests);
 };
 
@@ -97,7 +91,7 @@ exports["test doc languagesMacro"] = function testEmptyElements(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "languagesMacro", "{{languages}} macro", url, tests);
 };
 
@@ -114,7 +108,7 @@ exports["test doc emptyBrackets"] = function testEmptyBrackets(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "emptyBrackets", "empty brackets", url, tests);
 };
 
@@ -135,7 +129,7 @@ exports["test doc styleAttribute"] = function testStyleAttributes(assert, done) 
       ]
     }
   ];
-  
+
   runTests(assert, done, "styleAttribute", "'style' attribute", url, tests);
 };
 
@@ -156,7 +150,7 @@ exports["test doc nameAttribute"] = function testNameAttributes(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "nameAttribute", "'name' attribute", url, tests);
 };
 
@@ -175,7 +169,7 @@ exports["test doc spanCount"] = function testSpanElements(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "spanCount", "<span>", url, tests);
 };
 
@@ -196,7 +190,7 @@ exports["test doc preWithoutClass"] = function testPresWithoutClass(assert, done
       ]
     }
   ];
-  
+
   runTests(assert, done, "preWithoutClass", "<pre> w/o class", url, tests);
 };
 
@@ -215,7 +209,7 @@ exports["test doc summaryHeading"] = function testSummaryHeading(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "summaryHeading", "summary heading", url, tests);
 };
 
@@ -233,7 +227,7 @@ exports["test doc jsRefWithParams"] = function testJSRefWithParams(assert, done)
       ]
     }
   ];
-  
+
   runTests(assert, done, "jsRefWithParams", "{{JSRef}} with params", url, tests);
 };
 
@@ -252,7 +246,7 @@ exports["test doc exampleColonHeading"] = function testExampleColonHeading(asser
       ]
     }
   ];
-  
+
   runTests(assert, done, "exampleColonHeading", "'Example: ' heading", url, tests);
 };
 
@@ -272,7 +266,7 @@ exports["test doc alertPrintInCode"] = function testAlertPrintInCode(assert, don
       ]
     }
   ];
-  
+
   runTests(assert, done, "alertPrintInCode", "alert()/print()/eval()/document.write()", url, tests);
 };
 
@@ -301,7 +295,7 @@ exports["test doc fontElements"] = function testFontElements(assert, done) {
       expected: [
         '<font>Some text</font>',
         '<font face="Open Sans, sans-serif">Another text</font>'
-      ] 
+      ]
     }
   ];
 
@@ -320,7 +314,7 @@ exports["test doc httpLinks"] = function testHTTPLinks(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "httpLinks", "HTTP link", url, tests);
 };
 
@@ -411,7 +405,7 @@ exports["test doc macroSyntaxError"] = function testMacroSyntaxErrors(assert, do
       ]
     }
   ];
-  
+
   runTests(assert, done, "macroSyntaxError", "macro syntax error", url, tests);
 };
 
@@ -506,7 +500,7 @@ exports["test doc apiSyntaxHeadlines"] = function testSummaryHeading(assert, don
       ]
     }
   ];
-  
+
   runTests(assert, done, "apiSyntaxHeadlines", "API syntax headline", url, tests);
 };
 
@@ -527,7 +521,7 @@ exports["test doc codeInPre"] = function testSummaryHeading(assert, done) {
       ]
     }
   ];
-  
+
   runTests(assert, done, "codeInPre", "<code> in <pre>", url, tests);
 };
 
@@ -579,7 +573,7 @@ exports["test doc lineLengthInPre"] = function testSummaryHeading(assert, done) 
       ]
     }
   ];
-  
+
   runTests(assert, done, "lineLengthInPre", "too long line", url, tests);
 };
 


### PR DESCRIPTION
All tests were recreated to work on the DOM instead of text. This also required to recreate the unit tests and let them run on the document.

Because this is a huge change, it should be reviewed carefully.
I think it makes sense to make a new release first before merging this.

Sebastian
