### PR TITLE
Issue 90: Recognize shell prompts in code samples

### DIFF
--- a/data/tests/shell-prompts.js
+++ b/data/tests/shell-prompts.js
@@ -1,0 +1,24 @@
+docTests.shellPrompts = {
+  name: "shell_prompts",
+  desc: "shell_prompts_desc",
+  check: function checkShellPrompts(rootElement) {
+    var pres = rootElement.querySelectorAll("pre");
+    var matches = [];
+
+    for (var i = 0; i < pres.length; i++) {
+      var code = pres[i].innerHTML.replace(/<br\/?>/g, "\n").replace("&nbsp;", " ");
+      var shellPrompts = code.match(/^(?:\$|&gt;).*/gm);
+      if (shellPrompts) {
+        shellPrompts.forEach(function addMatch(shellPrompt) {
+          matches.push({
+            msg: shellPrompt.replace(/<.+?>/g, "")
+          });
+        });
+      }
+    }
+
+    return matches;
+  },
+  type: ERROR,
+  count: 0
+};

--- a/data/tests/testlist.js
+++ b/data/tests/testlist.js
@@ -14,6 +14,7 @@ exports.testList = [
   "jsref-with-params.js",
   "example-colon-heading.js",
   "alert-print-in-code.js",
+  "shell-prompts.js",
   "html-comments.js",
   "font-elements.js",
   "http-links.js",

--- a/locale/de.properties
+++ b/locale/de.properties
@@ -91,6 +91,12 @@ alert_print_in_code=alert, print, eval, document.write
 # Description of test checking for alert(), print(), eval() and document.write() within code samples
 alert_print_in_code_desc=alert(), print(), eval() oder document.write() sollten in Codebeispielen nicht verwendet werden.
 
+# Name of test checking for shell prompts within code samples
+shell_prompts=Shell Eingaben in Codebeispielen
+
+# Description of test checking for shell prompts within code samples
+shell_prompts_desc=Shell Befehle sollten nicht mit '$' oder '>' beginnen. Dies verwirrt mehr als dass es hilft und verursacht Probleme wenn sie kopiert werden.
+
 # Name of test checking for HTML comments
 html_comments=HTML-Kommentare
 

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -91,6 +91,12 @@ alert_print_in_code=alert, print, eval, document.write
 # Description of test checking for alert(), print(), eval() and document.write() within code samples
 alert_print_in_code_desc=Don't use alert(), print(), eval() or document.write() in code samples.
 
+# Name of test checking for shell prompts within code samples
+shell_prompts=Shell prompts in code samples
+
+# Description of test checking for shell prompts within code samples
+shell_prompts_desc=Don't start shell instructions with '$' or '>'. It confuses more than it helps and causes problems when copying them.
+
 # Name of test checking for HTML comments
 html_comments=HTML comments
 

--- a/test/test-shell-prompts.js
+++ b/test/test-shell-prompts.js
@@ -1,0 +1,26 @@
+const {url, runTests} = require("./testutils");
+
+exports["test doc shellPrompts"] = function testShellPrompts(assert, done) {
+  const tests = [
+    {
+      str: '<pre>somecommand</pre>' +
+           '<pre>$somecommand</pre>' +
+           '<pre>$ somecommand</pre>' +
+           '<pre>&gt;somecommand</pre>' +
+           '<pre>&gt; somecommand</pre>' +
+           '<pre>$ somecommand\noutput<br>$ anothercommand</pre>',
+      expected: [
+        '$somecommand',
+        '$ somecommand',
+        '&gt;somecommand',
+        '&gt; somecommand',
+        '$ somecommand',
+        '$ anothercommand'
+      ]
+    }
+  ];
+
+  runTests(assert, done, "shellPrompts", "shell prompts in code samples", url, tests);
+};
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
Note that the implementation does **not** differenciate whether the `$` or `>` is separated by a space from the code.
