### PR TITLE
Issue 138

### DIFF
--- a/data/tests/different-locale-links.js
+++ b/data/tests/different-locale-links.js
@@ -1,0 +1,25 @@
+docTests.differentLocaleLinks = {
+  name: "different_locale_links",
+  desc: "different_locale_links_desc",
+  check: function checkDifferentLocaleLinks(rootElement) {
+    var [, pageDomain, pageLocale] = document.URL.match(/^(?:https?:\/\/)(.+?)\/([^\/]+)/i) ||
+        ["", "developer.mozilla.org", "en-US"];
+    var links = rootElement.getElementsByTagName("a");
+    var matches = [];
+    for (var i = 0; i < links.length; i++) {
+      var href = links[i].getAttribute("href");
+      if (href) {
+        var [, linkDomain, linkLocale] = href.match(/^(?:https?:\/\/(.+?))?\/([^\/]+)/i);
+        if ((!linkDomain || linkDomain === pageDomain) && linkLocale !== pageLocale)
+        matches.push({
+          msg: "link_using_wrong_locale",
+          msgParams: [href, pageLocale]
+        });
+      }
+    }
+
+    return matches;
+  },
+  type: ERROR,
+  errors: []
+};

--- a/data/tests/testlist.js
+++ b/data/tests/testlist.js
@@ -3,6 +3,7 @@
 exports.testList = [
   "old-urls.js",
   "absolute-urls-for-internal-links.js",
+  "different-locale-links.js",
   "empty-elements.js",
   "languages-macro.js",
   "empty-brackets.js",

--- a/locale/de.properties
+++ b/locale/de.properties
@@ -22,6 +22,12 @@ absolute_urls_for_internal_links=Absolute URLs für interne Links
 # Description of test checking whether internal links contain absolute URLs
 absolute_urls_for_internal_links_desc=Interne Links sollte einen relativen URL-Pfad anstatt eines absoluten verwenden.
 
+# Name of test checking whether there are any links to different locales
+different_locale_links=Links zu anderen Übersetzungen
+
+# Description of test checking whether internal links contain absolute URLs
+different_locale_links_desc=Es sollte keine Links zu anderen Übersetzugen geben.
+
 # Name of test checking for empty elements
 empty_elements=Leere Elemente
 
@@ -159,6 +165,9 @@ url_in_link_title=URL in 'title' Attribut
 
 # Description of test checking whether there is a URL within the 'title' attribute of a link
 url_in_link_title_desc=Der URL eines Links wird bereits beim Darüberfahren mit dem Mauszeiger angezeigt, dadurch ist die Wiederholung innerhalb des 'title' Attributs überflüssig und sollte vermieden werden.
+
+# Error message for link using wrong locale
+link_using_wrong_locale=Link %s verwendet falsche Übersetzung. '%s' erwartet.
 
 # Error message for macro missing closing curly brace
 missing_closing_curly_brace=Makro fehlt schließende geschweifte Klammer: %s

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -22,6 +22,12 @@ absolute_urls_for_internal_links=Absolute URLs for internal links
 # Description of test checking whether internal links contain absolute URLs
 absolute_urls_for_internal_links_desc=Internal links should use a relative URL path instead of an absolute one.
 
+# Name of test checking whether there are any links to different locales
+different_locale_links=Different locale links
+
+# Description of test checking whether internal links contain absolute URLs
+different_locale_links_desc=There should not be any links pointing to other locales.
+
 # Name of test checking for empty elements
 empty_elements=Empty elements
 
@@ -159,6 +165,9 @@ url_in_link_title=URL in 'title' attribute
 
 # Description of test checking whether there is a URL within the 'title' attribute of a link
 url_in_link_title_desc=The URL of a link is already shown on hover, so repeating it within its 'title' attribute is redundant and should be avoided.
+
+# Error message for link using wrong locale
+link_using_wrong_locale=Link %s uses wrong locale. Expected '%s'.
 
 # Error message for macro missing closing curly brace
 missing_closing_curly_brace=Macro is missing a closing curly brace: %s

--- a/test/test-different-locale-links.js
+++ b/test/test-different-locale-links.js
@@ -1,0 +1,32 @@
+const {url, runTests} = require("./testutils");
+
+exports["test doc differentLocaleLinks"] = function testDifferentLocaleLinks(assert, done) {
+  const tests = [
+    {
+      str: '<a href="/en-US/docs/some/page">Page</a>' +
+           '<a href="http://developer.mozilla.org/en-US/docs/some/page">Page</a>' +
+           '<a href="https://developer.mozilla.org/en-US/docs/some/page">Page</a>' +
+           '<a href="/xx-YY/docs/some/page">Page</a>' +
+           '<a href="http://developer.mozilla.org/xx-YY/docs/some/page">Page</a>' +
+           '<a href="https://developer.mozilla.org/xx-YY/docs/some/page">Page</a>',
+      expected: [
+        {
+          msg: "link_using_wrong_locale",
+          msgParams: ["/xx-YY/docs/some/page", "en-US"]
+        },
+        {
+          msg: "link_using_wrong_locale",
+          msgParams: ["http://developer.mozilla.org/xx-YY/docs/some/page", "en-US"]
+        },
+        {
+          msg: "link_using_wrong_locale",
+          msgParams: ["https://developer.mozilla.org/xx-YY/docs/some/page", "en-US"]
+        }
+      ]
+    }
+  ];
+
+  runTests(assert, done, "differentLocaleLinks", "different locale links", url, tests);
+};
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
The test checks whether the page with the current locale contains links to pages in other locales.

_Note: Because the test doesn't have access to `document`, the unit test assumes `en-US` as locale._
