### PR TITLE
Issue 149: Excluded new paragraph helper from checks

### DIFF
--- a/data/tests/empty-elements.js
+++ b/data/tests/empty-elements.js
@@ -8,8 +8,19 @@ docTests.emptyElements = {
         {
           acceptNode: (node) => {
             // matching self-closing elements and excluding them
-            return !node.localName.match(/^(?:link|track|param|area|command|col|base|meta|hr|source|img|keygen|br|wbr|input)$/i) &&
-                node.textContent.match(/^(?:&nbsp;|\s|\n)*$/) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_CANCEL;
+            if (node.localName.match(/^(?:link|track|param|area|command|col|base|meta|hr|source|img|keygen|br|wbr|input)$/i)) {
+              return NodeFilter.FILTER_REJECT;
+            }
+
+            // Exclude new paragraph helper
+            if (node.localName === "span" && node.firstElementChild) {
+              var style = node.firstElementChild.getAttribute("style");
+              if (style && /z-index:\s*9999;/.test(style)) {
+                return NodeFilter.FILTER_REJECT;
+              }
+            }
+
+            return node.textContent.match(/^(?:&nbsp;|\s|\n)*$/) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
           }
         }
     );

--- a/data/tests/span-count.js
+++ b/data/tests/span-count.js
@@ -6,8 +6,21 @@ docTests.spanCount = {
     var matches = [];
 
     for (var i = 0; i < spanElements.length; i++) {
+      var node = spanElements[i];
+
+      // Exclude new paragraph helper
+      var style = node.getAttribute("style");
+      if (style && /z-index:\s*9999;/.test(style)) {
+        continue;
+      }
+
+      style = node.firstElementChild && node.firstElementChild.getAttribute("style");
+      if (style && /z-index:\s*9999;/.test(style)) {
+        continue;
+      }
+
       matches.push({
-        msg: spanElements[i].outerHTML
+        msg: node.outerHTML
       })
     }
 

--- a/data/tests/style-attribute.js
+++ b/data/tests/style-attribute.js
@@ -6,8 +6,23 @@ docTests.styleAttribute = {
     var matches = [];
 
     for (var i = 0; i < elementsWithStyleAttribute.length; i++) {
+      var node = elementsWithStyleAttribute[i];
+
+      // Exclude new paragraph helper
+      if (node.localName === "span") {
+        var style = node.getAttribute("style");
+        if (style && /z-index:\s*9999;/.test(style)) {
+          continue;
+        }
+
+        style = node.firstElementChild && node.firstElementChild.getAttribute("style");
+        if (style && /z-index:\s*9999;/.test(style)) {
+          continue;
+        }
+      }
+
       matches.push({
-        msg: 'style="' + elementsWithStyleAttribute[i].getAttribute("style") + '"'
+        msg: 'style="' + node.getAttribute("style") + '"'
       })
     }
 

--- a/test/test-empty-elements.js
+++ b/test/test-empty-elements.js
@@ -10,7 +10,8 @@ exports["test doc emptyElements"] = function testEmptyElements(assert, done) {
            '<img src="http://example.com/image.png">' +
            '<input value="test"/>' +
            '<p><span>some text</span></p>' +
-           '<p>some text</p>',
+           '<p>some text</p>' +
+           '<span><span style="display:block;z-index:9999;">&nbsp;</span></span>', // Simulates new paragraph helper
       expected: [
         '<p> </p>',
         '<p> \n\n </p>',

--- a/test/test-span-count.js
+++ b/test/test-span-count.js
@@ -7,7 +7,8 @@ exports["test doc spanCount"] = function testSpanElements(assert, done) {
            '<p>nope</p>' +
            '<span class="foo" style="font:10px">bar</span>' +
            '<span><dt>foobar</dt></span>' +
-           '<span class="seoSummary">seoseoseo</span>',
+           '<span class="seoSummary">seoseoseo</span>' +
+           '<span><span style="display:block;z-index:9999;">&nbsp;</span></span>', // Simulates new paragraph helper
       expected: [
         '<span>what?</span>',
         '<span class="foo" style="font:10px">bar</span>',

--- a/test/test-style-attribute.js
+++ b/test/test-style-attribute.js
@@ -7,7 +7,8 @@ exports["test doc styleAttribute"] = function testStyleAttributes(assert, done) 
            '<div style="margin-top:5%"></div>' +
            '<section style="background:#fff; color: rgb(234, 234, 234);"></section>' +
            '<b style=\'padding: 5px !important\'>test</b>' +
-           '<span style="font-family: \'Open Sans\', serif; line-height: 1.5"></span>',
+           '<span style="font-family: \'Open Sans\', serif; line-height: 1.5"></span>' +
+           '<span><span style="display:block;z-index:9999;">&nbsp;</span></span>', // Simulates new paragraph helper
       expected: [
         'style=""',
         'style="margin-top:5%"',


### PR DESCRIPTION
This change excludes errors in empty-elements, span-count and style-attribute caused by the the new paragraph helper (see issue #149).
