### PR TITLE
Issue 52: Moved error type to matches

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -5,8 +5,8 @@ const WARNING = 2;
 
 var docTests = {};
 
-function mapMatches(matches) {
+function mapMatches(matches, type) {
   return matches.map(match => {
-    return {msg: match};
+    return {msg: match, type: type};
   });
 }

--- a/data/sidebar.css
+++ b/data/sidebar.css
@@ -1,3 +1,11 @@
+:root {
+  --ok-color: #00882D;
+  --error-color: #CB000F;
+  --warning-color: #DBB40F;
+  --match-background: linear-gradient(rgba(255,255,255,0.2),rgba(255,255,255,0.2));
+  --match-highlighted-background: linear-gradient(rgba(255,255,255,0.3),rgba(255,255,255,0.3));
+}
+
 html, body {
   margin: 0;
 }
@@ -72,21 +80,21 @@ li {
   display: flex;
 }
 
-.hasErrors {
-  background-color: #CB000F;
-}
-
-.hasErrors > div,
-.hasWarnings > div {
+.hasErrors > .testHeading,
+.hasWarnings > .testHeading {
   cursor: pointer;
 }
 
+.hasErrors {
+  background-color: var(--error-color);
+}
+
 .hasWarnings {
-  background-color: #DBB40F;
+  background-color: var(--warning-color);
 }
 
 .ok {
-  background-color: #00882D;
+  background-color: var(--ok-color);
 }
 
 .testName {
@@ -108,19 +116,32 @@ li {
   padding-inline-start: 1.5em;
   padding-block-start: 0.3em;
   padding-block-end: 0.3em;
-  background-color: rgba(255, 255, 255, 0.2);
 }
 
-.hasErrors > .errors > li:not(:last-child) {
-  border-bottom: 2px solid #CB000F;
+.error {
+  background-color: var(--error-color);
+  background-image: var(--match-background);
 }
 
-.hasWarnings > .errors > li:not(:last-child) {
-  border-bottom: 2px solid #DBB40F;
+.warning {
+  background-color: var(--warning-color);
+  background-image: var(--match-background);
 }
 
-.errors > li:hover {
-  background-color: rgba(255, 255, 255, 0.3);
+.error:not(:last-child) {
+  border-bottom: 2px solid var(--error-color);
+}
+
+.warning:not(:last-child) {
+  border-bottom: 2px solid var(--warning-color);
+}
+
+.error:hover {
+  background-image: var(--match-highlighted-background);
+}
+
+.warning:hover {
+  background-image: var(--match-highlighted-background);
 }
 
 .show {

--- a/data/sidebar.js
+++ b/data/sidebar.js
@@ -1,3 +1,4 @@
+const ERROR = 1;
 const WARNING = 2;
 
 var totalErrorCount = 0;
@@ -7,8 +8,12 @@ addon.port.on("test", function(test, id, prefs) {
   var tests = document.getElementById("tests");
   var errorCount = test.errors.length;
   var status = "ok";
-  if (errorCount > 0) {
-    status = test.type === WARNING ? "hasWarnings" : "hasErrors";
+  if (errorCount !== 0) {
+    if (test.errors.some(match => match.type === ERROR)) {
+      status = "hasErrors";
+    } else if (test.errors.some(match => match.type === WARNING)) {
+      status = "hasWarnings";
+    }
   }
 
   tests.classList.toggle("hidePassingTests", prefs.hidePassingTests);
@@ -57,16 +62,14 @@ addon.port.on("test", function(test, id, prefs) {
   }
   test.errors.forEach(function(error) {
     var errorContainer = document.createElement("li");
+    errorContainer.setAttribute("class", error.type === WARNING ? "warning" : "error");
     errorContainer.textContent = error.msg;
     errors.appendChild(errorContainer);
   });
 
   if (errorCount !== 0) {
-    if (test.type === WARNING) {
-      totalWarningCount += errorCount;
-    } else {
-      totalErrorCount += errorCount;
-    }
+    totalWarningCount += test.errors.filter(match => match.type === WARNING).length;
+    totalErrorCount += test.errors.filter(match => match.type === ERROR).length;
   }
   updateErrorSummary();
 });

--- a/data/tests/absolute-urls-for-internal-links.js
+++ b/data/tests/absolute-urls-for-internal-links.js
@@ -15,6 +15,5 @@ docTests.absoluteURLsForInternalLinks = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/absolute-urls-for-internal-links.js
+++ b/data/tests/absolute-urls-for-internal-links.js
@@ -8,13 +8,13 @@ docTests.absoluteURLsForInternalLinks = {
       var href = links[i].getAttribute("href");
       if (href && href.match(/(?:https?:)?\/\/developer\.mozilla\.org\//i)) {
         matches.push({
-          msg: links[i].outerHTML
+          msg: links[i].outerHTML,
+          type: WARNING
         });
       }
     }
 
     return matches;
   },
-  type: WARNING,
   errors: []
 };

--- a/data/tests/alert-print-in-code.js
+++ b/data/tests/alert-print-in-code.js
@@ -6,11 +6,10 @@ docTests.alertPrintInCode = {
     var matches = [];
     for (var i = 0; i < pres.length; i++) {
       var preMatches = pres[i].textContent.match(/(?:alert|print|eval|document\.write)\s*\((?:.|\n)+?\)/gi) || [];
-      matches = matches.concat(mapMatches(preMatches));
+      matches = matches.concat(mapMatches(preMatches, ERROR));
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/alert-print-in-code.js
+++ b/data/tests/alert-print-in-code.js
@@ -10,6 +10,5 @@ docTests.alertPrintInCode = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/api-syntax-headlines.js
+++ b/data/tests/api-syntax-headlines.js
@@ -56,6 +56,5 @@ docTests.apiSyntaxHeadlines = {
     }
 
     return matches;
-  },
-  count: 0
+  }
 };

--- a/data/tests/api-syntax-headlines.js
+++ b/data/tests/api-syntax-headlines.js
@@ -38,7 +38,8 @@ docTests.apiSyntaxHeadlines = {
         if (disallowedNames.has(subHeading.toLowerCase())) {
           matches.push({
             msg: "invalid_headline_name",
-            msgParams: [subHeadings[i]]
+            msgParams: [subHeadings[i]],
+            type: ERROR
           });
         }
       }
@@ -47,7 +48,8 @@ docTests.apiSyntaxHeadlines = {
       for (var i = 1; i < order.length; i++) {
         if (order[i] < order[i - 1]) {
           matches.push({
-            msg: "invalid_headline_order"
+            msg: "invalid_headline_order",
+            type: ERROR
           });
         }
       }
@@ -55,6 +57,5 @@ docTests.apiSyntaxHeadlines = {
 
     return matches;
   },
-  type: ERROR,
   count: 0
 };

--- a/data/tests/code-in-pre.js
+++ b/data/tests/code-in-pre.js
@@ -13,6 +13,5 @@ docTests.codeInPre = {
     }
 
     return matches;
-  },
-  count: 0
+  }
 };

--- a/data/tests/code-in-pre.js
+++ b/data/tests/code-in-pre.js
@@ -7,12 +7,12 @@ docTests.codeInPre = {
 
     for (var i = 0; i < codesInPres.length; i++) {
       matches.push({
-        msg: codesInPres[i].outerHTML
+        msg: codesInPres[i].outerHTML,
+        type: ERROR
       });
     }
 
     return matches;
   },
-  type: ERROR,
   count: 0
 };

--- a/data/tests/different-locale-links.js
+++ b/data/tests/different-locale-links.js
@@ -15,14 +15,13 @@ docTests.differentLocaleLinks = {
             (!linkDomain || linkDomain === pageDomain)) {
           matches.push({
             msg: "link_using_wrong_locale",
-            msgParams: [href, pageLocale]
+            msgParams: [href, pageLocale],
+            type: ERROR
           });
         }
       }
     }
 
     return matches;
-  },
-  type: ERROR,
-  errors: []
+  }
 };

--- a/data/tests/empty-brackets.js
+++ b/data/tests/empty-brackets.js
@@ -17,13 +17,13 @@ docTests.emptyBrackets = {
       var textNodeMatches = treeWalker.currentNode.textContent.match(/\{\{\s*[a-z]*\(\)\s*?\}\}/gi) || [];
       textNodeMatches.forEach(match => {
         matches.push({
-          msg: match
+          msg: match,
+          type: ERROR
         });
       });
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/empty-brackets.js
+++ b/data/tests/empty-brackets.js
@@ -24,6 +24,5 @@ docTests.emptyBrackets = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/empty-elements.js
+++ b/data/tests/empty-elements.js
@@ -33,12 +33,12 @@ docTests.emptyElements = {
 
     while(treeWalker.nextNode()) {
       matches.push({
-        msg: treeWalker.currentNode.outerHTML
+        msg: treeWalker.currentNode.outerHTML,
+        type: ERROR
       });
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/empty-elements.js
+++ b/data/tests/empty-elements.js
@@ -39,6 +39,5 @@ docTests.emptyElements = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/example-colon-heading.js
+++ b/data/tests/example-colon-heading.js
@@ -15,6 +15,5 @@ docTests.exampleColonHeading = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/example-colon-heading.js
+++ b/data/tests/example-colon-heading.js
@@ -8,13 +8,13 @@ docTests.exampleColonHeading = {
     for (var i = 0; i < headlines.length; i++) {
       if (headlines[i].textContent.match(/^\s*Example:/)) {
         matches.push({
-          msg: headlines[i].outerHTML
+          msg: headlines[i].outerHTML,
+          type: ERROR
         })
       }
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/font-elements.js
+++ b/data/tests/font-elements.js
@@ -7,12 +7,12 @@ docTests.fontElements = {
 
     for (var i = 0; i < fontElements.length; i++) {
       matches.push({
-        msg: fontElements[i].outerHTML
+        msg: fontElements[i].outerHTML,
+        type: ERROR
       })
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/font-elements.js
+++ b/data/tests/font-elements.js
@@ -13,6 +13,5 @@ docTests.fontElements = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/html-comments.js
+++ b/data/tests/html-comments.js
@@ -16,6 +16,5 @@ docTests.htmlComments = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/html-comments.js
+++ b/data/tests/html-comments.js
@@ -10,12 +10,12 @@ docTests.htmlComments = {
 
     while(treeWalker.nextNode()) {
       matches.push({
-        msg: "<!--" + treeWalker.currentNode.data + "-->"
+        msg: "<!--" + treeWalker.currentNode.data + "-->",
+        type: ERROR
       });
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/http-links.js
+++ b/data/tests/http-links.js
@@ -7,12 +7,12 @@ docTests.httpLinks = {
 
     for (var i = 0; i < httpLinks.length; i++) {
       matches.push({
-        msg: httpLinks[i].outerHTML
+        msg: httpLinks[i].outerHTML,
+        type: WARNING
       })
     }
 
     return matches;
   },
-  type: WARNING,
   errors: []
 };

--- a/data/tests/http-links.js
+++ b/data/tests/http-links.js
@@ -13,6 +13,5 @@ docTests.httpLinks = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/invalid-macros.js
+++ b/data/tests/invalid-macros.js
@@ -116,7 +116,8 @@ docTests.invalidMacros = {
       while (macroNameMatch) {
         if (allowedMacros.indexOf(macroNameMatch[1].toLowerCase()) === -1) {
           matches.push({
-            msg: macroNameMatch[0]
+            msg: macroNameMatch[0],
+            type: WARNING
           });
         }
         macroNameMatch = reMacroName.exec(treeWalker.currentNode.textContent);
@@ -125,6 +126,5 @@ docTests.invalidMacros = {
 
     return matches;
   },
-  type: WARNING,
   errors: []
 };

--- a/data/tests/invalid-macros.js
+++ b/data/tests/invalid-macros.js
@@ -125,6 +125,5 @@ docTests.invalidMacros = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/jsref-with-params.js
+++ b/data/tests/jsref-with-params.js
@@ -17,13 +17,13 @@ docTests.jsRefWithParams = {
       var textNodeMatches = treeWalker.currentNode.textContent.match(/\{\{s*JSRef\(.*?\}\}/gi) || [];
       textNodeMatches.forEach(match => {
         matches.push({
-          msg: match
+          msg: match,
+          type: ERROR
         });
       });
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/jsref-with-params.js
+++ b/data/tests/jsref-with-params.js
@@ -24,6 +24,5 @@ docTests.jsRefWithParams = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/languages-macro.js
+++ b/data/tests/languages-macro.js
@@ -24,6 +24,5 @@ docTests.languagesMacro = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/languages-macro.js
+++ b/data/tests/languages-macro.js
@@ -17,13 +17,13 @@ docTests.languagesMacro = {
       var textNodeMatches = treeWalker.currentNode.textContent.match(/\{\{\s*languages.*?\}\}/gi);
       textNodeMatches.forEach(match => {
         matches.push({
-          msg: match
+          msg: match,
+          type: ERROR
         });
       });
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/line-length-in-pre.js
+++ b/data/tests/line-length-in-pre.js
@@ -20,6 +20,5 @@ docTests.lineLengthInPre = {
     }
 
     return mapMatches(matches, WARNING);
-  },
-  count: 0
+  }
 };

--- a/data/tests/line-length-in-pre.js
+++ b/data/tests/line-length-in-pre.js
@@ -19,8 +19,7 @@ docTests.lineLengthInPre = {
       }
     }
 
-    return mapMatches(matches);
+    return mapMatches(matches, WARNING);
   },
-  type: WARNING,
   count: 0
 };

--- a/data/tests/macro-syntax-error.js
+++ b/data/tests/macro-syntax-error.js
@@ -44,25 +44,29 @@ docTests.macroSyntaxError = {
         if (macro.match(/[^\}]\}$/)) {
           matches.push({
             msg: "missing_closing_curly_brace",
-            msgParams: [macro]
+            msgParams: [macro],
+            type: ERROR
           });
         }
         if (macro.match(/^\{\{[^\(]+\(.+?[^\)\s]\s*\}\}$/)) {
           matches.push({
             msg: "missing_closing_bracket",
-            msgParams: [macro]
+            msgParams: [macro],
+            type: ERROR
           });
         }
         if (!validateStringParams(macro)) {
           matches.push({
             msg: "string_parameter_incorrectly_quoted",
-            msgParams: [macro]
+            msgParams: [macro],
+            type: ERROR
           });
         }
         if (macro.match(/\){2,}\}{1,2}$/)) {
           matches.push({
             msg: "additional_closing_bracket",
-            msgParams: [macro]
+            msgParams: [macro],
+            type: ERROR
           });
         }
       });
@@ -70,6 +74,5 @@ docTests.macroSyntaxError = {
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/macro-syntax-error.js
+++ b/data/tests/macro-syntax-error.js
@@ -73,6 +73,5 @@ docTests.macroSyntaxError = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/name-attribute.js
+++ b/data/tests/name-attribute.js
@@ -7,12 +7,12 @@ docTests.nameAttribute = {
 
     for (var i = 0; i < elementsWithStyleAttribute.length; i++) {
       matches.push({
-        msg: 'name="' + elementsWithStyleAttribute[i].getAttribute("name") + '"'
+        msg: 'name="' + elementsWithStyleAttribute[i].getAttribute("name") + '"',
+        type: ERROR
       })
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/name-attribute.js
+++ b/data/tests/name-attribute.js
@@ -13,6 +13,5 @@ docTests.nameAttribute = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/old-urls.js
+++ b/data/tests/old-urls.js
@@ -17,6 +17,5 @@ docTests.oldURLs = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/old-urls.js
+++ b/data/tests/old-urls.js
@@ -10,13 +10,13 @@ docTests.oldURLs = {
       // i.e. a[href^='/en/' i] (see bug 888190, fixed in Firefox 47.0)
       if (links[i].getAttribute("href").match(/^\/en\//i)) {
         matches.push({
-          msg: links[i].outerHTML
+          msg: links[i].outerHTML,
+          type: ERROR
         });
       }
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/pre-without-class.js
+++ b/data/tests/pre-without-class.js
@@ -7,12 +7,12 @@ docTests.preWithoutClass = {
 
     for (var i = 0; i < presWithoutClass.length; i++) {
       matches.push({
-        msg: presWithoutClass[i].outerHTML
+        msg: presWithoutClass[i].outerHTML,
+        type: ERROR
       })
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/pre-without-class.js
+++ b/data/tests/pre-without-class.js
@@ -13,6 +13,5 @@ docTests.preWithoutClass = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/shell-prompts.js
+++ b/data/tests/shell-prompts.js
@@ -11,7 +11,8 @@ docTests.shellPrompts = {
       if (shellPrompts) {
         shellPrompts.forEach(function addMatch(shellPrompt) {
           matches.push({
-            msg: shellPrompt.replace(/<.+?>/g, "")
+            msg: shellPrompt.replace(/<.+?>/g, ""),
+            type: ERROR
           });
         });
       }
@@ -19,6 +20,5 @@ docTests.shellPrompts = {
 
     return matches;
   },
-  type: ERROR,
   count: 0
 };

--- a/data/tests/shell-prompts.js
+++ b/data/tests/shell-prompts.js
@@ -19,6 +19,5 @@ docTests.shellPrompts = {
     }
 
     return matches;
-  },
-  count: 0
+  }
 };

--- a/data/tests/span-count.js
+++ b/data/tests/span-count.js
@@ -26,6 +26,5 @@ docTests.spanCount = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/span-count.js
+++ b/data/tests/span-count.js
@@ -20,12 +20,12 @@ docTests.spanCount = {
       }
 
       matches.push({
-        msg: node.outerHTML
+        msg: node.outerHTML,
+        type: ERROR
       })
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/style-attribute.js
+++ b/data/tests/style-attribute.js
@@ -22,12 +22,12 @@ docTests.styleAttribute = {
       }
 
       matches.push({
-        msg: 'style="' + node.getAttribute("style") + '"'
+        msg: 'style="' + node.getAttribute("style") + '"',
+        type: ERROR
       })
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/style-attribute.js
+++ b/data/tests/style-attribute.js
@@ -28,6 +28,5 @@ docTests.styleAttribute = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/summary-heading.js
+++ b/data/tests/summary-heading.js
@@ -8,13 +8,13 @@ docTests.summaryHeading = {
     for (var i = 0; i < headlines.length; i++) {
       if (headlines[i].textContent.match(/^\s*Summary\s*$/)) {
         matches.push({
-          msg: headlines[i].outerHTML
+          msg: headlines[i].outerHTML,
+          type: ERROR
         })
       }
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/summary-heading.js
+++ b/data/tests/summary-heading.js
@@ -15,6 +15,5 @@ docTests.summaryHeading = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/url-in-link-title.js
+++ b/data/tests/url-in-link-title.js
@@ -19,6 +19,5 @@ docTests.urlInLinkTitle = {
     }
 
     return matches;
-  },
-  errors: []
+  }
 };

--- a/data/tests/url-in-link-title.js
+++ b/data/tests/url-in-link-title.js
@@ -12,13 +12,13 @@ docTests.urlInLinkTitle = {
           (title.match(/[a-z]{2}(?:-[A-Z]{2})?\/docs\/.*?\//) ||
            title === href.replace(/([a-z]{2})(?:-[a-z]{2})?\/docs\/(.*)/, "$1/$2")))) {
         matches.push({
-          msg: linkElements[i].outerHTML
+          msg: linkElements[i].outerHTML,
+          type: ERROR
         });
       }
     }
 
     return matches;
   },
-  type: ERROR,
   errors: []
 };

--- a/data/tests/wrong-highlighted-line.js
+++ b/data/tests/wrong-highlighted-line.js
@@ -67,6 +67,5 @@ docTests.wrongHighlightedLine = {
     }
 
     return matches;
-  },
-  count: 0
+  }
 };

--- a/data/tests/wrong-highlighted-line.js
+++ b/data/tests/wrong-highlighted-line.js
@@ -28,32 +28,37 @@ docTests.wrongHighlightedLine = {
           if (start <= 0) {
             matches.push({
               msg: "highlighted_line_number_not_positive",
-              msgParams: [String(start), match[1]]
+              msgParams: [String(start), match[1]],
+              type: ERROR
             });
           }
           if (start > lineCount) {
             matches.push({
               msg: "highlighted_line_number_too_big",
-              msgParams: [String(start), String(lineCount), match[1]]
+              msgParams: [String(start), String(lineCount), match[1]],
+              type: ERROR
             });
           }
           if (!Number.isNaN(end)) {
             if (end > lineCount) {
               matches.push({
                 msg: "highlighted_line_number_too_big",
-                msgParams: [String(end), String(lineCount), match[1]]
+                msgParams: [String(end), String(lineCount), match[1]],
+                type: ERROR
               });
             }
             if (end <= 0) {
               matches.push({
                 msg: "highlighted_line_number_not_positive",
-                msgParams: [String(end), match[1]]
+                msgParams: [String(end), match[1]],
+                type: ERROR
               });
             }
             if (start > end) {
               matches.push({
                 msg: "invalid_highlighted_range",
-                msgParams: [String(start), String(end), match[1]]
+                msgParams: [String(start), String(end), match[1]],
+                type: ERROR
               });
             }
           }
@@ -63,6 +68,5 @@ docTests.wrongHighlightedLine = {
 
     return matches;
   },
-  type: ERROR,
   count: 0
 };

--- a/data/tests/wrong-syntax-class.js
+++ b/data/tests/wrong-syntax-class.js
@@ -50,6 +50,5 @@ docTests.wrongSyntaxClass = {
     }
 
     return matches;
-  },
-  count: 0
+  }
 };

--- a/data/tests/wrong-syntax-class.js
+++ b/data/tests/wrong-syntax-class.js
@@ -8,7 +8,8 @@ docTests.wrongSyntaxClass = {
         if (element.localName === "pre" && element.className !== "syntaxbox") {
           return {
             msg: "wrong_syntax_class_used",
-            msgParams: [element.className]
+            msgParams: [element.className],
+            type: ERROR
           };
           break;
         }
@@ -50,6 +51,5 @@ docTests.wrongSyntaxClass = {
 
     return matches;
   },
-  type: ERROR,
   count: 0
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,7 +22,10 @@ var sidebar = require("sdk/ui/sidebar").Sidebar({
         testObj.name = localize(testObj.name);
         testObj.desc = localize(testObj.desc);
         testObj.errors.forEach((error, i, errors) => {
-          errors[i] = {msg: localize.apply(this, [error.msg].concat(error.msgParams))};
+          errors[i] = {
+            msg: localize.apply(this, [error.msg].concat(error.msgParams)),
+            type: error.type
+          };
         })
         sbWorker.port.emit("test", testObj, id, prefs);
       });


### PR DESCRIPTION
This change moves the error type from the test to the individual matches. This allows to assign different error types to the matches, that means one test can now produce different types of errors.
