### PR TITLE
Correct fix for issue #141

### DIFF
--- a/data/tests/macro-syntax-error.js
+++ b/data/tests/macro-syntax-error.js
@@ -26,7 +26,7 @@ docTests.macroSyntaxError = {
       }
       return stringParamQuote === "";
     }
-
+    
     var treeWalker = document.createTreeWalker(
         rootElement,
         NodeFilter.SHOW_TEXT,
@@ -47,7 +47,7 @@ docTests.macroSyntaxError = {
             msgParams: [macro]
           });
         }
-        if (macro.match(/^\{\{[^\(]+\([^\)]*\}\}$/)) {
+        if (macro.match(/^\{\{[^\(]+\(.+?[^\)\s]\s*\}\}$/)) {
           matches.push({
             msg: "missing_closing_bracket",
             msgParams: [macro]

--- a/test/test-macro-syntax-error.js
+++ b/test/test-macro-syntax-error.js
@@ -22,7 +22,8 @@ exports["test doc macroSyntaxError"] = function testMacroSyntaxErrors(assert, do
            '{{macro("param"}}' + // Missing closing parameter list bracket after double quoted parameter
            '{{macro(\'param\'}}' + // Missing closing parameter list bracket after single quoted parameter
            '{{macro(param"}}' + // Missing opening double quote and missing closing parameter list bracket
-           '{{macro(param"))}}', // Missing opening double quote and double closing parameter list bracket
+           '{{macro(param"))}}' + // Missing opening double quote and double closing parameter list bracket
+           '{{macro(123, "param()"}}', // Missing closing parameter list bracket after string parameter containing bracket
       expected: [
         {
           msg: "string_parameter_incorrectly_quoted",
@@ -83,6 +84,10 @@ exports["test doc macroSyntaxError"] = function testMacroSyntaxErrors(assert, do
         {
           msg: "additional_closing_bracket",
           msgParams: ['{{macro(param"))}}']
+        },
+        {
+          msg: "missing_closing_bracket",
+          msgParams: ['{{macro(123, "param()"}}']
         }
       ]
     }


### PR DESCRIPTION
This fixes the detection of missing closing parameter list brackets for macros containing string parameters with brackets.
In regard of the failed approach of #147, the syntax of the regular expression got simplified again.

Sebastian
