### PR TITLE
Issue 138 followup: Fixed NPE in case there were no matches for the URL

### DIFF
--- a/data/tests/different-locale-links.js
+++ b/data/tests/different-locale-links.js
@@ -9,7 +9,8 @@ docTests.differentLocaleLinks = {
     for (var i = 0; i < links.length; i++) {
       var href = links[i].getAttribute("href");
       if (href) {
-        var [, linkDomain, linkLocale] = href.match(/^(?:https?:\/\/(.+?))?\/([^\/]+)/i);
+        var [, linkDomain, linkLocale] = href.match(/^(?:https?:\/\/(.+?))?\/([^\/]+)/i) ||
+            [null, null, null];
         if ((!linkDomain || linkDomain === pageDomain) && linkLocale !== pageLocale)
         matches.push({
           msg: "link_using_wrong_locale",

--- a/data/tests/different-locale-links.js
+++ b/data/tests/different-locale-links.js
@@ -11,11 +11,13 @@ docTests.differentLocaleLinks = {
       if (href) {
         var [, linkDomain, linkLocale] = href.match(/^(?:https?:\/\/(.+?))?\/([^\/]+)/i) ||
             [null, null, null];
-        if ((!linkDomain || linkDomain === pageDomain) && linkLocale !== pageLocale)
-        matches.push({
-          msg: "link_using_wrong_locale",
-          msgParams: [href, pageLocale]
-        });
+        if (linkLocale && linkLocale.toLowerCase() !== pageLocale.toLowerCase() &&
+            (!linkDomain || linkDomain === pageDomain)) {
+          matches.push({
+            msg: "link_using_wrong_locale",
+            msgParams: [href, pageLocale]
+          });
+        }
       }
     }
 


### PR DESCRIPTION
If the URL doesn't have a path, e.g. like https://mozilla.org/, the regexp fails and causes a null pointer exception. This will be caught with this patch.

Sebastian
