### PR TITLE
Issue 17: Added word count and reading time estimation

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -2,6 +2,7 @@
 
 const ERROR = 1;
 const WARNING = 2;
+const INFO = 3;
 
 let docTests = {};
 

--- a/data/sidebar.css
+++ b/data/sidebar.css
@@ -2,6 +2,7 @@
   --ok-color: #00882D;
   --error-color: #CB000F;
   --warning-color: #DBB40F;
+  --info-color: #0095DD;
   --match-background: linear-gradient(rgba(255,255,255,0.2),rgba(255,255,255,0.2));
   --match-highlighted-background: linear-gradient(rgba(255,255,255,0.3),rgba(255,255,255,0.3));
 }
@@ -81,7 +82,8 @@ li {
 }
 
 .hasErrors > .testHeading,
-.hasWarnings > .testHeading {
+.hasWarnings > .testHeading,
+.hasInfo > .testHeading {
   cursor: pointer;
 }
 
@@ -91,6 +93,10 @@ li {
 
 .hasWarnings {
   background-color: var(--warning-color);
+}
+
+.hasInfo {
+  background-color: var(--info-color);
 }
 
 .ok {
@@ -118,14 +124,22 @@ li {
   padding-block-end: 0.3em;
 }
 
+.error,
+.warning,
+.info {
+  background-image: var(--match-background);
+}
+
 .error {
   background-color: var(--error-color);
-  background-image: var(--match-background);
 }
 
 .warning {
   background-color: var(--warning-color);
-  background-image: var(--match-background);
+}
+
+.info {
+  background-color: var(--info-color);
 }
 
 .error:not(:last-child) {
@@ -136,11 +150,13 @@ li {
   border-bottom: 2px solid var(--warning-color);
 }
 
-.error:hover {
-  background-image: var(--match-highlighted-background);
+.info:not(:last-child) {
+  border-bottom: 2px solid var(--info-color);
 }
 
-.warning:hover {
+.error:hover,
+.warning:hover,
+.info:hover {
   background-image: var(--match-highlighted-background);
 }
 

--- a/data/sidebar.js
+++ b/data/sidebar.js
@@ -1,5 +1,6 @@
 const ERROR = 1;
 const WARNING = 2;
+const INFO = 3;
 
 let totalErrorCount = 0;
 let totalWarningCount = 0;
@@ -13,6 +14,8 @@ addon.port.on("showTestResult", function(test, id, prefs) {
       status = "hasErrors";
     } else if (test.errors.some(match => match.type === WARNING)) {
       status = "hasWarnings";
+    } else if (test.errors.every(match => match.type === INFO)) {
+      status = "hasInfo";
     }
   }
   let oldWarningCount = 0;
@@ -29,7 +32,7 @@ addon.port.on("showTestResult", function(test, id, prefs) {
     testElem.dataset.errorCount = newErrorCount;
     testElem.dataset.warningCount = newWarningCount;
     testElem.getElementsByClassName("errorCount")[0].textContent = matchesCount;
-    testElem.classList.remove("hasErrors", "hasWarnings", "ok");
+    testElem.classList.remove("hasErrors", "hasWarnings", "hasInfo", "ok");
     testElem.classList.add(status);
   } else {
     let testContainer = document.createElement("li");
@@ -72,7 +75,17 @@ addon.port.on("showTestResult", function(test, id, prefs) {
   }
   test.errors.forEach(function(error) {
     let errorContainer = document.createElement("li");
-    errorContainer.setAttribute("class", error.type === WARNING ? "warning" : "error");
+    let errorClass = "error";
+    switch (error.type) {
+      case WARNING:
+        errorClass = "warning";
+        break;
+
+      case INFO:
+        errorClass = "info";
+        break;
+    }
+    errorContainer.setAttribute("class", errorClass);
     errorContainer.textContent = error.msg;
     errors.appendChild(errorContainer);
   });
@@ -139,7 +152,7 @@ window.addEventListener("DOMContentLoaded", function loadTestSuite() {
     let testHeading = getParentByClassName(evt.originalTarget, "testHeading");
     if (testHeading) {
       let testElem = getParentByClassName(testHeading, "test");
-      if (testElem.classList.contains("hasErrors") || testElem.classList.contains("hasWarnings")) {
+      if (!testElem.classList.contains("ok")) {
         testElem.getElementsByClassName("errors")[0].classList.toggle("show");
       }
     }

--- a/data/tests/article-length.js
+++ b/data/tests/article-length.js
@@ -1,4 +1,3 @@
-const LONG_ARTICLE_WORD_COUNT_THRESHOLD = 1000;
 const WORDS_PER_MINUTE = 275;
 
 docTests.articleLength = {
@@ -16,7 +15,7 @@ docTests.articleLength = {
       msgParams: [String(wordCount), String(readTimeEstimation)],
       type: INFO
     }];
-    if (wordCount > LONG_ARTICLE_WORD_COUNT_THRESHOLD) {
+    if (wordCount > self.options.LONG_ARTICLE_WORD_COUNT_THRESHOLD) {
       matches.push({
         msg: "long_article",
         type: WARNING

--- a/data/tests/article-length.js
+++ b/data/tests/article-length.js
@@ -1,0 +1,27 @@
+const LONG_ARTICLE_WORD_COUNT_THRESHOLD = 1000;
+const WORDS_PER_MINUTE = 275;
+
+docTests.articleLength = {
+  name: "article_length",
+  desc: "article_length_desc",
+  check: function checkArticleLength(rootElement) {
+    let text = rootElement.textContent;
+    let wordCount = text.match(/\w+/g).length;
+    let readTimeEstimation = Math.round(wordCount / WORDS_PER_MINUTE);
+    if (readTimeEstimation === 0) {
+      readTimeEstimation = "< 1";
+    }
+    let matches = [{
+      msg: "article_length_info",
+      msgParams: [String(wordCount), String(readTimeEstimation)],
+      type: INFO
+    }];
+    if (wordCount > LONG_ARTICLE_WORD_COUNT_THRESHOLD) {
+      matches.push({
+        msg: "long_article",
+        type: WARNING
+      });
+    }
+    return matches;
+  }
+};

--- a/data/tests/testlist.js
+++ b/data/tests/testlist.js
@@ -26,5 +26,6 @@ exports.testList = [
   "wrong-syntax-class.js",
   "code-in-pre.js",
   "line-length-in-pre.js",
-  "url-in-link-title.js"
+  "url-in-link-title.js",
+  "article-length.js"
 ];

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,12 +1,12 @@
 const data = require("sdk/self").data;
 const tabs = require("sdk/tabs");
 const localize = require("sdk/l10n").get;
-const prefs = require('sdk/simple-prefs').prefs;
+const prefs = require("sdk/simple-prefs").prefs;
 const testList = require("../data/tests/testlist").testList;
 
 let sidebar = require("sdk/ui/sidebar").Sidebar({
-  id: 'mdn-doc-tests',
-  title: 'MDN documentation tester',
+  id: "mdn-doc-tests",
+  title: "MDN documentation tester",
   url: data.url("sidebar.html"),
   onReady: function (sbWorker) {
     sbWorker.port.on("runTests", function() {
@@ -15,7 +15,10 @@ let sidebar = require("sdk/ui/sidebar").Sidebar({
           "./doctests.js",
           ...testList.map(test => "./tests/" + test),
           "./runtests.js"
-        ]
+        ],
+        contentScriptOptions: {
+          LONG_ARTICLE_WORD_COUNT_THRESHOLD: prefs.longArticleWordCountThreshold
+        }
       });
       tabWorker.port.emit("runTests");
       tabWorker.port.on("processTestResult", function(testObj, id){

--- a/locale/de.properties
+++ b/locale/de.properties
@@ -166,6 +166,12 @@ url_in_link_title=URL in 'title' Attribut
 # Description of test checking whether there is a URL within the 'title' attribute of a link
 url_in_link_title_desc=Der URL eines Links wird bereits beim Darüberfahren mit dem Mauszeiger angezeigt, dadurch ist die Wiederholung innerhalb des 'title' Attributs überflüssig und sollte vermieden werden.
 
+# Name of test checking the length of the article
+article_length=Artikellänge
+
+# Description of test checking the length of the article
+article_length_desc=Hinweise zur Länge des Artikels
+
 # Error message for link using wrong locale
 link_using_wrong_locale=Link %s verwendet falsche Übersetzung. '%s' erwartet.
 
@@ -198,6 +204,12 @@ invalid_headline_order=Ungültige Reihenfolge
 
 # Error message for invalid CSS class for the syntax definition block
 wrong_syntax_class_used=Die für den Syntaxdefinitionsblock verwendete CSS-Klasse '%s' ist falsch. Sie muss 'syntaxbox' sein.
+
+# Info message for article length and reading time estimation
+article_length_info=Der Artikel hat %s Wörter. Geschätzte Lesezeit: %s Minute(n).
+
+# Error message for long article
+long_article=Der Artikel ist sehr lang. Er sollte in kleinere Artikel aufgeteilt werden.
 
 # Title of 'autoExpandErrors' property (shown in Add-ons Manager)
 autoExpandErrors_title=Fehler automatisch erweitern

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -166,6 +166,12 @@ url_in_link_title=URL in 'title' attribute
 # Description of test checking whether there is a URL within the 'title' attribute of a link
 url_in_link_title_desc=The URL of a link is already shown on hover, so repeating it within its 'title' attribute is redundant and should be avoided.
 
+# Name of test checking the length of the article
+article_length=Article length
+
+# Description of test checking the length of the article
+article_length_desc=Hints regarding the length of the article.
+
 # Error message for link using wrong locale
 link_using_wrong_locale=Link %s uses wrong locale. Expected '%s'.
 
@@ -198,6 +204,12 @@ invalid_headline_order=Invalid order
 
 # Error message for invalid CSS class for the syntax definition block
 wrong_syntax_class_used=The CSS class '%s' used for the syntax definition block is wrong. It must be 'syntaxbox'.
+
+# Info message for article length and reading time estimation
+article_length_info=The article has %s words. Estimated read time: %s minute(s).
+
+# Error message for long article
+long_article=The article is very long. Consider to split it up into smaller articles.
 
 # Title of 'autoExpandErrors' property (shown in Add-ons Manager)
 autoExpandErrors_title=Automatically expand errors

--- a/package.json
+++ b/package.json
@@ -23,6 +23,13 @@
       "title": "Hide passing tests",
       "type": "bool",
       "value": false
+    },
+    {
+      "name": "longArticleWordCountThreshold",
+      "title": "Long article word count threshold",
+      "type": "integer",
+      "value": 2000,
+      "hidden": true
     }
   ],
   "permissions": {

--- a/test/test-article-length.js
+++ b/test/test-article-length.js
@@ -1,0 +1,40 @@
+const {url, runTests} = require("./testutils");
+
+exports["test doc articleLength"] = function testArticleLength(assert, done) {
+  const tests = [
+    {
+      str: Array(100).fill("foo").join(" "),
+      expected: [
+        {
+          msg: "article_length_info",
+          msgParams: ["100", "< 1"]
+        }
+      ]
+    },
+    {
+      str: Array(500).fill("foo").join(" "),
+      expected: [
+        {
+          msg: "article_length_info",
+          msgParams: ["500", "2"]
+        }
+      ]
+    },
+    {
+      str: Array(2000).fill("foo").join(" "),
+      expected: [
+        {
+          msg: "article_length_info",
+          msgParams: ["2000", "7"]
+        },
+        {
+          msg: "long_article"
+        }
+      ]
+    }
+  ];
+
+  runTests(assert, done, "articleLength", "article length", url, tests);
+};
+
+require("sdk/test").run(exports);

--- a/test/test-article-length.js
+++ b/test/test-article-length.js
@@ -21,11 +21,11 @@ exports["test doc articleLength"] = function testArticleLength(assert, done) {
       ]
     },
     {
-      str: Array(2000).fill("foo").join(" "),
+      str: Array(3000).fill("foo").join(" "),
       expected: [
         {
           msg: "article_length_info",
-          msgParams: ["2000", "7"]
+          msgParams: ["3000", "11"]
         },
         {
           msg: "long_article"

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,5 +1,6 @@
 // Utility functions that execute unit tests
 
+const prefs = require("sdk/simple-prefs").prefs;
 const testList = require("../data/tests/testlist").testList;
 
 exports.url = "about:blank";
@@ -14,7 +15,8 @@ exports.runTests = function runTests(assert, done, name, desc, url, tests) {
           "./doctests.js",
           ...testList.map(test => "./tests/" + test),
           "../test/testrunner.js"],
-        contentScriptOptions: {"name": name, "tests": JSON.stringify(tests)}
+        contentScriptOptions: {"name": name, "tests": JSON.stringify(tests),
+            LONG_ARTICLE_WORD_COUNT_THRESHOLD: prefs.longArticleWordCountThreshold}
       });
 
       let resultCount = 0;


### PR DESCRIPTION
This new approach uses the same regular expression as the previous one in the [issue-17 branch](https://github.com/Elchi3/mdn-doc-tests/tree/issue-17), though it is much faster, as it just works on the text content and doesn't need to remove the HTML tags first.

It outputs the word count and read time estimation as info message and adds a warning in case the text is longer than 1000 words.

Sebastian
