### PR TITLE
Issue 166: React to 'pageshow' event

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -43,5 +43,6 @@ let isEditing = function(tab) {
   }
 };
 
-tabs.on('activate', function(tab) { isEditing(tab); });
-tabs.on('ready', function(tab) { isEditing(tabs.activeTab); });
+tabs.on("activate", function(tab) { isEditing(tab); });
+tabs.on("ready", function(tab) { isEditing(tabs.activeTab); });
+tabs.on("pageshow", function(tab) { isEditing(tabs.activeTab); });


### PR DESCRIPTION
When navigating within the browser history and the page is loaded from BFCache the 'activate' and 'ready' events are not fired.

Therefore we also need to listen to the 'pageshow' event.

Sebastian
