### PR TITLE
Issue 170: Refactored creation and handling of tab worker

### DIFF
--- a/data/runtests.js
+++ b/data/runtests.js
@@ -1,12 +1,4 @@
-let iframe = document.querySelectorAll("iframe.cke_wysiwyg_frame")[0];
-let content = "";
-let rootElement = null;
-if (iframe) {
-  iframe.contentDocument.body.setAttribute("spellcheck", "true");
-  rootElement = iframe.contentDocument.body;
-}
-
-let runTest = function(testObj, id) {
+function runTest(testObj, id, rootElement) {
   // Only run the test suite if there's a root element
   //(e.g. when in source view there's no root element set)
   if (rootElement) {
@@ -17,8 +9,13 @@ let runTest = function(testObj, id) {
 };
 
 self.port.on("runTests", function() {
-  for (let prop in docTests) {
-    runTest(docTests[prop], prop);
+  let iframe = document.querySelector("iframe.cke_wysiwyg_frame");
+  if (iframe) {
+    rootElement = iframe.contentDocument.body;
+
+    for (let prop in docTests) {
+      runTest(docTests[prop], prop, rootElement);
+    }
   }
 });
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,6 +3,10 @@ const tabs = require("sdk/tabs");
 const localize = require("sdk/l10n").get;
 const prefs = require("sdk/simple-prefs").prefs;
 const testList = require("../data/tests/testlist").testList;
+const editURL= /https:\/\/developer\.mozilla\.org\/.+(?:\$(?:edit|translate)|\/docs\/new(?:\?|$))/;
+const templateURL= /https:\/\/developer\.mozilla\.org\/.+?\/docs\/(?:templates|Template(?::|%3A))/;
+
+let tabWorkers = new WeakMap();
 
 let sidebar = require("sdk/ui/sidebar").Sidebar({
   id: "mdn-doc-tests",
@@ -10,16 +14,7 @@ let sidebar = require("sdk/ui/sidebar").Sidebar({
   url: data.url("sidebar.html"),
   onReady: function (sbWorker) {
     sbWorker.port.on("runTests", function() {
-      tabWorker = tabs.activeTab.attach({
-        contentScriptFile: [
-          "./doctests.js",
-          ...testList.map(test => "./tests/" + test),
-          "./runtests.js"
-        ],
-        contentScriptOptions: {
-          LONG_ARTICLE_WORD_COUNT_THRESHOLD: prefs.longArticleWordCountThreshold
-        }
-      });
+      let tabWorker = tabWorkers.get(tabs.activeTab);
       tabWorker.port.emit("runTests");
       tabWorker.port.on("processTestResult", function(testObj, id){
         testObj.name = localize(testObj.name);
@@ -36,16 +31,38 @@ let sidebar = require("sdk/ui/sidebar").Sidebar({
   }
 });
 
-let isEditing = function(tab) {
-  let editURL= /https:\/\/developer\.mozilla\.org\/.+(?:\$(?:edit|translate)|\/docs\/new(?:\?|$))/;
-  let templateURL= /https:\/\/developer\.mozilla\.org\/.+?\/docs\/(?:templates|Template(?::|%3A))/;
+function initializeTestingEnvironment(tab, overwriteWorker) {
   if (editURL.test(tab.url) && !templateURL.test(tab.url)) {
+    if (!tabWorkers.has(tab) || overwriteWorker) {
+      let tabWorker = tab.attach({
+        contentScriptFile: [
+          "./doctests.js",
+          ...testList.map(test => "./tests/" + test),
+          "./runtests.js"
+        ],
+        contentScriptOptions: {
+          LONG_ARTICLE_WORD_COUNT_THRESHOLD: prefs.longArticleWordCountThreshold
+        }
+      });
+      tabWorkers.set(tab, tabWorker);
+    }
+  }
+  toggleSidebar();
+};
+
+function destroyTestingEnvironment(tab) {
+  tabWorkers.remove(tab);
+};
+
+function toggleSidebar() {
+  if (editURL.test(tabs.activeTab.url) && !templateURL.test(tabs.activeTab.url)) {
     sidebar.show();
   } else {
     sidebar.hide();
   }
 };
 
-tabs.on("activate", function(tab) { isEditing(tab); });
-tabs.on("ready", function(tab) { isEditing(tabs.activeTab); });
-tabs.on("pageshow", function(tab) { isEditing(tabs.activeTab); });
+tabs.on("activate", toggleSidebar);
+tabs.on("ready", initializeTestingEnvironment);
+tabs.on("pagehide", destroyTestingEnvironment);
+tabs.on("pageshow", initializeTestingEnvironment);


### PR DESCRIPTION
This patch changes the tab worker creation, so that's it happens only once and independently from the sidebar creation and test suite runs.

This is achieved by moving the initialization code for the tab worker out of the `runTests` event handler and keeping the tab worker as long as the tab is open. It will be kept even when you navigate to another tab and is 'reconnected' with the sidebar worker when the test suite is run.

Sebastian
