### PR TITLE
Issue 174: Consider <pre> without class as valid in some cases

### DIFF
--- a/data/tests/pre-without-class.js
+++ b/data/tests/pre-without-class.js
@@ -8,7 +8,7 @@ docTests.preWithoutClass = {
     for (let i = 0; i < presWithoutClass.length; i++) {
       matches.push({
         msg: presWithoutClass[i].outerHTML,
-        type: ERROR
+        type: WARNING
       })
     }
 

--- a/data/tests/pre-without-class.js
+++ b/data/tests/pre-without-class.js
@@ -6,9 +6,21 @@ docTests.preWithoutClass = {
     let matches = [];
 
     for (let i = 0; i < presWithoutClass.length; i++) {
+      // If the content is recognized as folder structure, don't add a warning for empty <pre>
+      if (presWithoutClass[i].textContent.match(/^\S[^\n\*]*\/\n/)) {
+        continue;
+      }
+
+      let type = WARNING;
+
+      // If the content is recognized as code or {{csssyntax}} macro, mark it as error
+      if (presWithoutClass[i].textContent.match(/^\s*(?:\/\*.+?\*\/|<.+?>|@[^\s\n]+[^\n]*\{\n|\{\{\s*csssyntax(?:\(\))?\s*\}\})/)) {
+        type = ERROR;
+      }
+      
       matches.push({
         msg: presWithoutClass[i].outerHTML,
-        type: WARNING
+        type: type
       })
     }
 

--- a/locale/de.properties
+++ b/locale/de.properties
@@ -68,7 +68,7 @@ span_elements_desc=Die Verwendung von <span> Elementen sollte vermieden und stat
 pre_without_class=<pre> ohne Klasse
 
 # Description of test checking for <pre> elements without 'class' attribute
-pre_without_class_desc=<pre> Elemente müssen ein 'class' Attribut haben, sodass deren Syntax hervorgehoben wird.
+pre_without_class_desc=<pre> Elemente müssen in den meisten Fällen ein 'class' Attribut haben, sodass deren Syntax hervorgehoben wird.
 
 # Name of test checking for summary heading
 summary_heading='Summary' Überschrift

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -68,7 +68,7 @@ span_elements_desc=Using <span> elements should be avoided and other elements be
 pre_without_class=<pre> w/o class
 
 # Description of test checking for <pre> elements without 'class' attribute
-pre_without_class_desc=<pre> elements must have a 'class' attribute assigned, so their syntax is highlighted.
+pre_without_class_desc=<pre> elements must have a 'class' attribute assigned in most cases, so their syntax is highlighted.
 
 # Name of test checking for summary heading
 summary_heading=Summary heading

--- a/test/test-pre-without-class.js
+++ b/test/test-pre-without-class.js
@@ -4,13 +4,20 @@ exports["test doc preWithoutClass"] = function testPresWithoutClass(assert, done
   const tests = [
     {
       str: '<pre class="brush: js"></pre>' +
-           '<pre>foobar;</pre>' +
            '<pre class="syntaxbox"></pre>' +
+           '<pre>folder/\n  file</pre>' +
+           '<pre>foobar;</pre>' +
+           '<pre>/* comment */\nvar code;</pre>' +
+           '<pre>@rule param {\n  descriptor: value;\n}</pre>' +
+           '<pre>&lt;tag&gt;</pre>' +
            '<pre id="foo"></pre>' +
            '<pre class="">foo</pre>' +
            '<pre> \n\r foo</pre>',
       expected: [
         '<pre>foobar;</pre>',
+        '<pre>/* comment */\nvar code;</pre>',
+        '<pre>@rule param {\n  descriptor: value;\n}</pre>',
+        '<pre>&lt;tag&gt;</pre>',
         '<pre id="foo"></pre>',
         '<pre class="">foo</pre>',
         '<pre> \n\n foo</pre>'


### PR DESCRIPTION
Adjusted the test case, so that it recognizes invalid and valid uses of `<pre>` without class and outputs the results as warnings or errors accordingly.

Sebastian
