### PR TITLE
Issue 156: Moved check for new paragraph helper into utility function

### DIFF
--- a/data/doctests.js
+++ b/data/doctests.js
@@ -10,3 +10,12 @@ function mapMatches(matches, type) {
     return {msg: match, type: type};
   });
 }
+
+function isNewParagraphHelper(element) {
+  if (!element || element.localName !== "span") {
+    return false;
+  }
+
+  let style = element.getAttribute("style");
+  return style && /z-index:\s*9999;/.test(style);
+}

--- a/data/tests/empty-elements.js
+++ b/data/tests/empty-elements.js
@@ -12,11 +12,8 @@ docTests.emptyElements = {
                 node.textContent.match(/^(?:&nbsp;|\s|\n)*$/)) {
 
               // Exclude new paragraph helper
-              if (node.localName === "span" && node.firstElementChild) {
-                let style = node.firstElementChild.getAttribute("style");
-                if (style && /z-index:\s*9999;/.test(style)) {
-                  return NodeFilter.FILTER_REJECT;
-                }
+              if (isNewParagraphHelper(node.firstElementChild)) {
+                return NodeFilter.FILTER_REJECT;
               }
 
               // Elements containing self-closing elements except <br> and <wbr> are considered non-empty

--- a/data/tests/span-count.js
+++ b/data/tests/span-count.js
@@ -9,13 +9,7 @@ docTests.spanCount = {
       let node = spanElements[i];
 
       // Exclude new paragraph helper
-      let style = node.getAttribute("style");
-      if (style && /z-index:\s*9999;/.test(style)) {
-        continue;
-      }
-
-      style = node.firstElementChild && node.firstElementChild.getAttribute("style");
-      if (style && /z-index:\s*9999;/.test(style)) {
+      if (isNewParagraphHelper(node) || isNewParagraphHelper(node.firstElementChild)) {
         continue;
       }
 

--- a/data/tests/style-attribute.js
+++ b/data/tests/style-attribute.js
@@ -9,16 +9,8 @@ docTests.styleAttribute = {
       let node = elementsWithStyleAttribute[i];
 
       // Exclude new paragraph helper
-      if (node.localName === "span") {
-        let style = node.getAttribute("style");
-        if (style && /z-index:\s*9999;/.test(style)) {
-          continue;
-        }
-
-        style = node.firstElementChild && node.firstElementChild.getAttribute("style");
-        if (style && /z-index:\s*9999;/.test(style)) {
-          continue;
-        }
+      if (isNewParagraphHelper(node) || isNewParagraphHelper(node.firstElementChild)) {
+        continue;
       }
 
       matches.push({


### PR DESCRIPTION
A new function `isNewParagraphHelper()` was created, which checks whether a given element is a new paragraph helper.
