### PR TITLE
Added spellchecking back

### DIFF
--- a/data/runtests.js
+++ b/data/runtests.js
@@ -38,3 +38,16 @@ if (comment) {
     disableBtns(false);
   });
 }
+
+window.addEventListener("load", function injectIFrame() {
+  window.removeEventListener("load", injectIFrame);
+
+  // Using a timeout to add the spellchecking, because the iframe is not loaded immediately and
+  // there doesn't seem to be a proper event to react to.
+  setTimeout(() => {
+    let iframe = document.querySelector("iframe.cke_wysiwyg_frame");
+    if (iframe) {
+      iframe.contentDocument.body.setAttribute("spellcheck", "true");
+    }
+  }, 1000);
+});


### PR DESCRIPTION
This brings back spellchecking to the document editor.

Unfortunately I couldn't find a better to solution to add this than a timeout. When the 'load' event is fired, the iframe may not exist yet and the `CKEDITOR` variable is also not available at this point to to register a listener for when the editor is loaded.

Sebastian
