### PR TITLE
Skip unavailable tests in unit tests

### DIFF
--- a/test/testrunner.js
+++ b/test/testrunner.js
@@ -1,13 +1,15 @@
 // This test runner is called from unit tests only
 
 let testObj = docTests[self.options.name];
-let rootElement = document.createElement('div');
+let rootElement = document.createElement("div");
 let tests = JSON.parse(self.options.tests);
 
 tests.forEach(test => {
   rootElement.innerHTML = test.str;
-  let matches = testObj.check(rootElement);
-  testObj.errors = matches;
-  testObj.expected = test.expected;
-  self.port.emit('processTestResult', testObj, self.options.name);
+  if (testObj) {
+    let matches = testObj.check(rootElement);
+    testObj.errors = matches;
+    testObj.expected = test.expected;
+  }
+  self.port.emit("processTestResult", testObj, self.options.name);
 });


### PR DESCRIPTION
As mentioned in issue #184 this patch allows to disable tests and their corresponding unit tests by simply commenting them out within testlist.js.

Disadvantage may be that tests, which don't get registered due to some bug like using the wrong test name, don't cause an error.

Sebastian
