### PR TITLE
Adding tab worker listener on initialization instead when running the test suite

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -7,26 +7,17 @@ const editURL= /https:\/\/developer\.mozilla\.org\/.+(?:\$(?:edit|translate)|\/d
 const templateURL= /https:\/\/developer\.mozilla\.org\/.+?\/docs\/(?:templates|Template(?::|%3A))/;
 
 let tabWorkers = new WeakMap();
+let sidebarWorker = null;
 
 let sidebar = require("sdk/ui/sidebar").Sidebar({
   id: "mdn-doc-tests",
   title: "MDN documentation tester",
   url: data.url("sidebar.html"),
   onReady: function (sbWorker) {
+    sidebarWorker = sbWorker;
     sbWorker.port.on("runTests", function() {
       let tabWorker = tabWorkers.get(tabs.activeTab);
       tabWorker.port.emit("runTests");
-      tabWorker.port.on("processTestResult", function(testObj, id){
-        testObj.name = localize(testObj.name);
-        testObj.desc = localize(testObj.desc);
-        testObj.errors.forEach((error, i, errors) => {
-          errors[i] = {
-            msg: localize.apply(this, [error.msg].concat(error.msgParams)),
-            type: error.type
-          };
-        })
-        sbWorker.port.emit("showTestResult", testObj, id, prefs);
-      });
     });
   }
 });
@@ -44,6 +35,21 @@ function initializeTestingEnvironment(tab, overwriteWorker) {
           LONG_ARTICLE_WORD_COUNT_THRESHOLD: prefs.longArticleWordCountThreshold
         }
       });
+      tabWorker.port.on("processTestResult", function(testObj, id){
+        testObj.name = localize(testObj.name);
+        testObj.desc = localize(testObj.desc);
+        testObj.errors.forEach((error, i, errors) => {
+          errors[i] = {
+            msg: localize.apply(this, [error.msg].concat(error.msgParams)),
+            type: error.type
+          };
+        });
+
+        if (sidebarWorker) {
+          sidebarWorker.port.emit("showTestResult", testObj, id, prefs);
+        }
+      });
+
       tabWorkers.set(tab, tabWorker);
     }
   }


### PR DESCRIPTION
So far, a new tab worker listener was attached every time the `runTests` event was triggered, i.e. every time the test suite is run. That's wrong, as it just needs to be attached once.

This patch moves the attaching of the tab worker listener to the initialization code of the tab worker.

Sebastian
