### PR TITLE
Issue 195: Test that sidebar macros are not wrapped in <p> but in <div>

### DIFF
--- a/data/tests/incorrectly-wrapped-sidebar-macros.js
+++ b/data/tests/incorrectly-wrapped-sidebar-macros.js
@@ -2,7 +2,7 @@ docTests.wrongWrappedSidebarMacros = {
   name: "wrong_wrapped_sidebar_macros",
   desc: "wrong_wrapped_sidebar_macros_desc",
   check: function checkWrongWrappedSidebarMacros(rootElement) {
-    const allowedMacros = /^(?:|apiref|cssref|htmlref|makesimplequicklinks|mathmlref|svgrefelem)$|sidebar$/i;
+    const allowedMacros = /^(?:apiref|cssref|htmlref|makesimplequicklinks|mathmlref|svgrefelem)$|sidebar$/i;
 
     let treeWalker = document.createTreeWalker(
         rootElement,

--- a/data/tests/incorrectly-wrapped-sidebar-macros.js
+++ b/data/tests/incorrectly-wrapped-sidebar-macros.js
@@ -2,7 +2,7 @@ docTests.incorrectlyWrappedSidebarMacros = {
   name: "incorrectly_wrapped_sidebar_macros",
   desc: "incorrectly_wrapped_sidebar_macros_desc",
   check: function checkIncorrectlyWrappedSidebarMacros(rootElement) {
-    const allowedMacros = /^(?:apiref|cssref|htmlref|makesimplequicklinks|mathmlref|svgrefelem)$|sidebar$/i;
+    const allowedMacros = /^(?:apiref|cssref|htmlref|jsref|makesimplequicklinks|mathmlref|svgrefelem)$|sidebar$/i;
 
     let treeWalker = document.createTreeWalker(
         rootElement,

--- a/data/tests/incorrectly-wrapped-sidebar-macros.js
+++ b/data/tests/incorrectly-wrapped-sidebar-macros.js
@@ -1,7 +1,7 @@
-docTests.wrongWrappedSidebarMacros = {
-  name: "wrong_wrapped_sidebar_macros",
-  desc: "wrong_wrapped_sidebar_macros_desc",
-  check: function checkWrongWrappedSidebarMacros(rootElement) {
+docTests.incorrectlyWrappedSidebarMacros = {
+  name: "incorrectly_wrapped_sidebar_macros",
+  desc: "incorrectly_wrapped_sidebar_macros_desc",
+  check: function checkIncorrectlyWrappedSidebarMacros(rootElement) {
     const allowedMacros = /^(?:apiref|cssref|htmlref|makesimplequicklinks|mathmlref|svgrefelem)$|sidebar$/i;
 
     let treeWalker = document.createTreeWalker(

--- a/data/tests/testlist.js
+++ b/data/tests/testlist.js
@@ -19,6 +19,7 @@ exports.testList = [
   "font-elements.js",
   "http-links.js",
   "invalid-macros.js",
+  "wrong-wrapped-sidebar-macros.js",
   "macro-syntax-error.js",
   "wrong-highlighted-line.js",
   "api-syntax-headlines.js",

--- a/data/tests/testlist.js
+++ b/data/tests/testlist.js
@@ -19,7 +19,7 @@ exports.testList = [
   "font-elements.js",
   "http-links.js",
   "invalid-macros.js",
-  "wrong-wrapped-sidebar-macros.js",
+  "incorrectly-wrapped-sidebar-macros.js",
   "macro-syntax-error.js",
   "wrong-highlighted-line.js",
   "api-syntax-headlines.js",

--- a/data/tests/wrong-wrapped-sidebar-macros.js
+++ b/data/tests/wrong-wrapped-sidebar-macros.js
@@ -1,0 +1,36 @@
+docTests.wrongWrappedSidebarMacros = {
+  name: "wrong_wrapped_sidebar_macros",
+  desc: "wrong_wrapped_sidebar_macros_desc",
+  check: function checkWrongWrappedSidebarMacros(rootElement) {
+    const allowedMacros = /^(?:|apiref|cssref|htmlref|makesimplequicklinks|mathmlref|svgrefelem)$|sidebar$/i;
+
+    let treeWalker = document.createTreeWalker(
+        rootElement,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode: (node) => {
+            return node.textContent.match(/\{\{.*?\}\}/) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+          }
+        }
+    );
+    let matches = [];
+
+    while(treeWalker.nextNode()) {
+      let reMacroName = /\{\{\s*([^\(\}\s]+).*?\}\}/g;
+      let macroNameMatch = reMacroName.exec(treeWalker.currentNode.textContent);
+      while (macroNameMatch) {
+        if (macroNameMatch[1].match(allowedMacros) !== null &&
+            treeWalker.currentNode.parentElement.localName !== 'div') {
+          matches.push({
+            msg: "wrong_element_wrapping_sidebar_macro",
+            msgParams: [macroNameMatch[0], treeWalker.currentNode.parentElement.localName],
+            type: ERROR
+          });
+        }
+        macroNameMatch = reMacroName.exec(treeWalker.currentNode.textContent);
+      }
+    }
+
+    return matches;
+  }
+};

--- a/locale/de.properties
+++ b/locale/de.properties
@@ -118,6 +118,12 @@ invalid_macros=Ungültige Makros
 # Description of test checking for invalid macros
 invalid_macros_desc=Das verwendete Makro ist nicht erlaubt oder existiert nicht
 
+# Name of test checking incorrectly wrapped sidebar macros
+incorrectly_wrapped_sidebar_macros=Inkorrekt gepackte Sidebar-Makros
+
+# Description of test checking incorrectly wrapped sidebar macros
+incorrectly_wrapped_sidebar_macros_desc=Sidebar-Makros müssen in <div> Elemente gepackt werden
+
 # Name of test checking for macro syntax errors
 macro_syntax_error=Makrosyntaxfehler
 
@@ -180,6 +186,9 @@ string_parameter_incorrectly_quoted=Anführungszeichen für Stringparameter sind
 
 # Error message for macro having additional closing brackets
 additional_closing_bracket=Makro hat zusätzliche schließende Klammer(n): %s
+
+# Error message for sidebar macro wrapped into wrong element
+wrong_element_wrapping_sidebar_macro=Sidebar-Makro %s ist in <%s> Element gepackt
 
 # Error message for obsolete macro
 obsolete_macro=Das %s Makro ist veraltet und sollte entfernt werden.

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -124,6 +124,12 @@ invalid_macros=Invalid macros
 # Description of test checking for invalid macros
 invalid_macros_desc=The used macro is not allowed or does not exist
 
+# Name of test checking incorrectly wrapped sidebar macros
+incorrectly_wrapped_sidebar_macros=Incorrectly wrapped sidebar macros
+
+# Description of test checking incorrectly wrapped sidebar macros
+incorrectly_wrapped_sidebar_macros_desc=Sidebar macros must be wrapped into <div> elements
+
 # Name of test checking for wrong highlighted line within code samples
 wrong_highlighted_line=Wrong highlighted line
 
@@ -180,6 +186,9 @@ string_parameter_incorrectly_quoted=String parameter is not quoted correctly: %s
 
 # Error message for macro having additional closing brackets
 additional_closing_bracket=Macro has additional closing bracket(s): %s
+
+# Error message for sidebar macro wrapped into wrong element
+wrong_element_wrapping_sidebar_macro=Sidebar macro %s is wrapped into <%s> element
 
 # Error message for obsolete macro
 obsolete_macro=The %s macro is obsolete and should be removed.

--- a/test/test-incorrectly-wrapped-sidebar-macros.js
+++ b/test/test-incorrectly-wrapped-sidebar-macros.js
@@ -1,0 +1,59 @@
+const {ERROR, WARNING, url, runTests} = require("./testutils");
+
+exports["test doc incorrectlyWrappedSidebarMacros"] = function testIncorrectlyWrappedSidebarMacros(assert, done) {
+  const tests = [
+    {
+      str: '<div>{{CSSRef}}</div>',
+      expected: []
+    },
+    {
+      str: '<div>{{HTMLRef}}</div>',
+      expected: []
+    },
+    {
+      str: '<div>{{APIRef}}</div>',
+      expected: []
+    },
+    {
+      str: '<div>{{SVGRefElem}}</div>',
+      expected: []
+    },
+    {
+      str: '<div>{{JSSidebar}}</div>',
+      expected: []
+    },
+    {
+      str: '<div>{{AddonSidebar}}</div>',
+      expected: []
+    },
+    {
+      str: '<div>{{ APIRef("Some API") }}</div>',
+      expected: []
+    },
+    {
+      str: '<p>{{CSSRef}}</p>',
+      expected: [
+        {
+          msg: "wrong_element_wrapping_sidebar_macro",
+          msgParams: ["{{CSSRef}}", "p"],
+          type: ERROR
+        }
+      ]
+    },
+    {
+      str: '<span>{{ APIRef("Some API") }}</span>',
+      expected: [
+        {
+          msg: "wrong_element_wrapping_sidebar_macro",
+          msgParams: ["{{ APIRef(\"Some API\") }}", "span"],
+          type: ERROR
+        }
+      ]
+    }
+  ];
+
+  runTests(assert, done, "incorrectlyWrappedSidebarMacros", "incorrectly wrapped sidebar macros",
+      url, tests);
+};
+
+require("sdk/test").run(exports);

--- a/test/test-incorrectly-wrapped-sidebar-macros.js
+++ b/test/test-incorrectly-wrapped-sidebar-macros.js
@@ -15,6 +15,10 @@ exports["test doc incorrectlyWrappedSidebarMacros"] = function testIncorrectlyWr
       expected: []
     },
     {
+      str: '<div>{{JSRef}}</div>',
+      expected: []
+    },
+    {
       str: '<div>{{SVGRefElem}}</div>',
       expected: []
     },


### PR DESCRIPTION
This test checks whether the macros named `apiref`, `cssref`, `htmlref`, `makesimplequicklinks`, `mathmlref`, and `svgrefelem` and macros ending with `sidebar` are wrapped into other tags than `<div>`s.

Sebastian
