### PR TITLE
Issue 134: Added automatic test suite triggering

### DIFF
--- a/data/runtests.js
+++ b/data/runtests.js
@@ -1,3 +1,27 @@
+const RUN_TESTS_DELAY = 500;
+
+let runTestsTimeout = null;
+
+window.setTimeout(initializeKeyEventHandler, 1000);
+
+function initializeKeyEventHandler() {
+  let iframe = document.querySelector("iframe.cke_wysiwyg_frame");
+  iframe.contentWindow.addEventListener("keyup", runTestsAfterTimeout);
+  iframe.contentWindow.addEventListener("keydown", resetRunTestsTimeout);
+  
+  function runTestsAfterTimeout() {
+    runTestsTimeout = window.setTimeout(runTests, RUN_TESTS_DELAY);
+  }
+  
+  function resetRunTestsTimeout() {
+    window.clearTimeout(runTestsTimeout);
+  }
+  
+  let ckeditor = document.getElementById("id_content");
+  ckeditor.addEventListener("keyup", runTestsAfterTimeout);
+  ckeditor.addEventListener("keydown", resetRunTestsTimeout);
+}
+
 function runTest(testObj, id, rootElement) {
   // Only run the test suite if there's a root element
   //(e.g. when in source view there's no root element set)
@@ -8,16 +32,19 @@ function runTest(testObj, id, rootElement) {
   }
 };
 
-self.port.on("runTests", function() {
+function runTests() {
   let iframe = document.querySelector("iframe.cke_wysiwyg_frame");
   if (iframe) {
-    rootElement = iframe.contentDocument.body;
-
+    let rootElement = iframe.contentDocument.body;
     for (let prop in docTests) {
       runTest(docTests[prop], prop, rootElement);
     }
   }
   self.port.emit("finishedTests");
+}
+
+self.port.on("runTests", function() {
+  runTests();
 });
 
 let btns = document.querySelectorAll(".btn-save, .btn-save-and-edit");

--- a/data/runtests.js
+++ b/data/runtests.js
@@ -69,12 +69,15 @@ if (comment) {
 window.addEventListener("load", function injectIFrame() {
   window.removeEventListener("load", injectIFrame);
 
-  // Using a timeout to add the spellchecking, because the iframe is not loaded immediately and
-  // there doesn't seem to be a proper event to react to.
-  setTimeout(() => {
+  // Using polling to add the spellchecking and initially run the tests,
+  // because the iframe is not loaded immediately and there doesn't seem
+  // to be a proper event to react to.
+  let checkIfIframeLoadedInterval = setInterval(() => {
     let iframe = document.querySelector("iframe.cke_wysiwyg_frame");
     if (iframe) {
+      clearInterval(checkIfIframeLoadedInterval);
       iframe.contentDocument.body.setAttribute("spellcheck", "true");
+      runTests();
     }
-  }, 1000);
+  }, 50);
 });

--- a/data/sidebar.js
+++ b/data/sidebar.js
@@ -158,8 +158,6 @@ window.addEventListener("DOMContentLoaded", function loadTestSuite() {
   let runTestsButton = document.getElementById("btn-runtests");
   runTestsButton.addEventListener("click", runTests);
 
-  setInterval(runTests, 10000);
-
   let tests = document.getElementById("tests");
   tests.addEventListener("click", (evt) => {
     let testHeading = getParentByClassName(evt.originalTarget, "testHeading");

--- a/lib/main.js
+++ b/lib/main.js
@@ -64,6 +64,26 @@ function destroyTestingEnvironment(tab) {
 
 function toggleSidebar() {
   if (editURL.test(tabs.activeTab.url) && !templateURL.test(tabs.activeTab.url)) {
+    if (!tabWorkers.has(tab) || overwriteWorker) {
+      let tabWorker = tab.attach({
+        contentScriptFile: [
+          "./doctests.js",
+          ...testList.map(test => "./tests/" + test),
+          "./runtests.js"
+        ]
+      });
+      tabWorkers.set(tab, tabWorker);
+    }
+  }
+  toggleSidebar();
+};
+
+function destroyTestingEnvironment(tab) {
+  tabWorkers.remove(tab);
+};
+
+function toggleSidebar() {
+  if (editURL.test(tabs.activeTab.url) && !templateURL.test(tabs.activeTab.url)) {
     sidebar.show();
   } else {
     sidebar.hide();

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,8 +15,11 @@ let sidebar = require("sdk/ui/sidebar").Sidebar({
   url: data.url("sidebar.html"),
   onReady: function (sbWorker) {
     sidebarWorker = sbWorker;
-    sbWorker.port.on("runTests", function() {
-      let tabWorker = tabWorkers.get(tabs.activeTab);
+
+    let tabWorker = tabWorkers.get(tabs.activeTab);
+    tabWorker.port.emit("runTests");
+
+    sidebarWorker.port.on("runTests", function() {
       tabWorker.port.emit("runTests");
       tabWorker.port.on("finishedTests", () => sidebarWorker.port.emit("hideProgressBar"));
     });
@@ -62,25 +65,13 @@ function destroyTestingEnvironment(tab) {
   tabWorkers.remove(tab);
 };
 
-function toggleSidebar() {
-  if (editURL.test(tabs.activeTab.url) && !templateURL.test(tabs.activeTab.url)) {
-    if (!tabWorkers.has(tab) || overwriteWorker) {
-      let tabWorker = tab.attach({
-        contentScriptFile: [
-          "./doctests.js",
-          ...testList.map(test => "./tests/" + test),
-          "./runtests.js"
-        ]
-      });
-      tabWorkers.set(tab, tabWorker);
-    }
-  }
+function handleTabSwitch() {
   toggleSidebar();
-};
-
-function destroyTestingEnvironment(tab) {
-  tabWorkers.remove(tab);
-};
+  let tabWorker = tabWorkers.get(tabs.activeTab) || initializeTestingEnvironment(tabs.activeTab, true);
+  if (tabWorker) {
+    tabWorker.port.emit("runTests");
+  }
+}
 
 function toggleSidebar() {
   if (editURL.test(tabs.activeTab.url) && !templateURL.test(tabs.activeTab.url)) {
@@ -90,7 +81,7 @@ function toggleSidebar() {
   }
 };
 
-tabs.on("activate", toggleSidebar);
+tabs.on("activate", handleTabSwitch);
 tabs.on("ready", initializeTestingEnvironment);
 tabs.on("pagehide", destroyTestingEnvironment);
 tabs.on("pageshow", initializeTestingEnvironment);


### PR DESCRIPTION
This patch runs the test suite almost immediately after the page is loaded, on tab switches and on key stroke (after a timeout).

Two things could still be improved:
- Polling is used to get to know when the iframe is available to run the test suite, as there doesn't seem to be a proper event to react to.
- Not all cases of changes are covered yet like pasting contents via the mouse.

Sebastian
