### PR TITLE
Issue 214: API headlines: "Exceptions thrown" not marked as invalid

### DIFF
--- a/data/tests/api-syntax-headlines.js
+++ b/data/tests/api-syntax-headlines.js
@@ -13,12 +13,13 @@
  *  expects the headlines to be <h3> elements under a <h2>Syntax</h2> section.
  */
 
-const disallowedNames = new Map([["returns", "Return value"], ["errors", "Exceptions"],
+const disallowedNames = new Map([["arguments", "Parameters"], ["returns", "Return value"],
+    ["exceptions thrown", "Exceptions"], ["errors", "Exceptions"],
     ["errors thrown", "Exceptions"]]);
 const validOrder = [
-  new Set(["parameters"]),
+  new Set(["parameters", "arguments"]),
   new Set(["return value", "returns"]),
-  new Set(["exceptions", "errors", "errors thrown"])
+  new Set(["exceptions", "exceptions thrown", "errors", "errors thrown"])
 ];
 
 docTests.apiSyntaxHeadlines = {

--- a/test/test-api-syntax-headlines.js
+++ b/test/test-api-syntax-headlines.js
@@ -4,18 +4,23 @@ exports["test doc apiSyntaxHeadlines"] = function testSummaryHeading(assert, don
   const tests = [
     {
       str: '<h2 id="Syntax">Syntax</h2>' +
-           '<h3>Errors</h3>' +
+           '<h3>Exceptions thrown</h3>' +
            '<h3>Returns</h3>' +
-           '<h3>Parameters</h3>',
+           '<h3>Arguments</h3>',
       expected: [
         {
           msg: "invalid_headline_name",
-          msgParams: ["Errors"],
+          msgParams: ["Exceptions thrown"],
           type: ERROR
         },
         {
           msg: "invalid_headline_name",
           msgParams: ["Returns"],
+          type: ERROR
+        },
+        {
+          msg: "invalid_headline_name",
+          msgParams: ["Arguments"],
           type: ERROR
         },
         {
@@ -37,6 +42,32 @@ exports["test doc apiSyntaxHeadlines"] = function testSummaryHeading(assert, don
           type: ERROR
         }
       ]
+    },
+    {
+      str: '<h2 id="Syntax">Syntax</h2>' +
+           '<h3>Return value</h3>' +
+           '<h3>Errors</h3>',
+      expected: [
+        {
+          msg: "invalid_headline_name",
+          msgParams: ["Errors"],
+          type: ERROR
+        }
+      ],
+      expectedAfterFixing: []
+    },
+    {
+      str: '<h2 id="Syntax">Syntax</h2>' +
+           '<h3>Return value</h3>' +
+           '<h3>Errors thrown</h3>',
+      expected: [
+        {
+          msg: "invalid_headline_name",
+          msgParams: ["Errors thrown"],
+          type: ERROR
+        }
+      ],
+      expectedAfterFixing: []
     }
   ];
 


### PR DESCRIPTION
Added "arguments" as erroneous headline for parameters and and "exceptions thrown" for exceptions.
Also, updated the unit tests to cover all errors.