### PR TITLE
Add no_tag_omission to allowedMacros

### DIFF
--- a/data/tests/invalid-macros.js
+++ b/data/tests/invalid-macros.js
@@ -97,6 +97,7 @@ docTests.invalidMacros = {
       "mathmlelement",
       "mathmlref",
       "next",
+      "no_tag_omission",
       "non-standard_header",
       "non-standard_inline",
       "noscript_inline",


### PR DESCRIPTION
The `no_tag_omission`macro is used in many HTML element pages.