### PR TITLE
Suppress element-element check for <td>

### DIFF
--- a/data/tests/empty-elements.js
+++ b/data/tests/empty-elements.js
@@ -17,8 +17,9 @@ docTests.emptyElements = {
         NodeFilter.SHOW_ELEMENT,
         {
           acceptNode: (node) => {
-            // matching self-closing elements and excluding them
+            // matching self-closing elements and td elements and excluding them
             if(!node.localName.match(/^link|track|param|area|command|col|base|meta|hr|source|img|keygen|br|wbr|input$/i) &&
+                !node.localName.match(/^td$/i) &&
                 node.textContent.match(/^(?:&nbsp;|\s|\n)*$/)) {
 
               // Exclude new paragraph helper


### PR DESCRIPTION
Empty cells in tables are a common case. In particular, in the Specifications
table for the Elements pages, it’s common for the Comments column for some rows
to be empty (when no comment is necessary or useful).